### PR TITLE
refactor to use sync.Map and sync.Once for writer

### DIFF
--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -18,8 +18,8 @@ type Writer struct {
 }
 
 var (
-	regMtx         sync.RWMutex
-	serializers    = make(map[formats.Format]native.Serializer)
+	serializers    sync.Map
+	once           sync.Once
 	defaultOptions = &Options{
 		RenderOptions: &native.RenderOptions{
 			Indent: 4,
@@ -30,6 +30,7 @@ var (
 )
 
 func New(opts ...WriterOption) *Writer {
+	ensureSerializersInitialized()
 	w := &Writer{
 		Options: defaultOptions,
 	}
@@ -41,49 +42,47 @@ func New(opts ...WriterOption) *Writer {
 	return w
 }
 
-func init() {
-	regMtx.Lock()
-	serializers[formats.CDX10JSON] = drivers.NewCDX("1.0", formats.JSON)
-	serializers[formats.CDX11JSON] = drivers.NewCDX("1.1", formats.JSON)
-	serializers[formats.CDX12JSON] = drivers.NewCDX("1.2", formats.JSON)
-	serializers[formats.CDX13JSON] = drivers.NewCDX("1.3", formats.JSON)
-	serializers[formats.CDX14JSON] = drivers.NewCDX("1.4", formats.JSON)
-	serializers[formats.CDX15JSON] = drivers.NewCDX("1.5", formats.JSON)
-	serializers[formats.SPDX23JSON] = drivers.NewSPDX23()
-	regMtx.Unlock()
+func ensureSerializersInitialized() {
+	once.Do(func() {
+		serializers.Store(formats.CDX10JSON, drivers.NewCDX("1.0", formats.JSON))
+		serializers.Store(formats.CDX11JSON, drivers.NewCDX("1.1", formats.JSON))
+		serializers.Store(formats.CDX12JSON, drivers.NewCDX("1.2", formats.JSON))
+		serializers.Store(formats.CDX13JSON, drivers.NewCDX("1.3", formats.JSON))
+		serializers.Store(formats.CDX14JSON, drivers.NewCDX("1.4", formats.JSON))
+		serializers.Store(formats.CDX15JSON, drivers.NewCDX("1.5", formats.JSON))
+		serializers.Store(formats.SPDX23JSON, drivers.NewSPDX23())
+	})
 }
 
-// RegisterSerializer registers a new serializer to handle writing serialized
-// SBOMs in a specific format. When registerring a new serializer it replaces
-// any other previously defined for the same format.
+// RegisterSerializer adds a new serializer for the specified format.
 func RegisterSerializer(format formats.Format, s native.Serializer) {
-	regMtx.Lock()
-	serializers[format] = s
-	regMtx.Unlock()
+	ensureSerializersInitialized()
+	serializers.Store(format, s)
 }
 
-// UnregisterSerializer removes a serializer from the list of available
+// UnregisterSerializer removes a serializer for the specified format.
 func UnregisterSerializer(format formats.Format) {
-	regMtx.Lock()
-	delete(serializers, format)
-	regMtx.Unlock()
+	ensureSerializersInitialized()
+	serializers.Delete(format)
 }
 
-// GetFormatSerializer returns the registered serializer for a specific format. If
-// format is a blank string or no serializer for the format is registered, it will
-// return an error.
+// GetFormatSerializer retrieves a serializer for the specified format.
+// It ensures that serializers are initialized before attempting to load the serializer for the given format.
 func GetFormatSerializer(format formats.Format) (native.Serializer, error) {
+	ensureSerializersInitialized()
 	if format == "" {
 		return nil, errors.New("unable to find serializer, no format specified")
 	}
-	if _, ok := serializers[format]; ok {
-		return serializers[format], nil
+	if serializer, ok := serializers.Load(format); ok {
+		if serializer == nil {
+			return nil, nil
+		}
+		return serializer.(native.Serializer), nil
 	}
-	return nil, fmt.Errorf("no serializer registered for %s", format)
+	return nil, fmt.Errorf("unable to find serializer for format %s", format)
 }
 
-// WriteStreamWithOptions writes an SBOM in a native format to the stream w using
-// the options set o.
+// WriteStreamWithOptions writes an SBOM in a native format to the stream w using the options set o.
 func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o *Options) error {
 	if bom == nil {
 		return fmt.Errorf("unable to write sbom to stream, SBOM is nil")


### PR DESCRIPTION
- refactored the code to use sync.Once and sync.Map primitives