### PR TITLE
Fix missing relationships in nodelist.RelateNodeAtID()

### DIFF
--- a/pkg/sbom/edge.go
+++ b/pkg/sbom/edge.go
@@ -248,3 +248,21 @@ func (e *Edge) flatString() string {
 	sort.Strings(tos)
 	return e.From + ":" + e.Type.String() + ":" + strings.Join(tos, "+")
 }
+
+// AddDestinationById adds identifiers to the destination list of the edge. The
+// new destination identifiers are guaranteed to be added only once and will
+// not be duplicated if there is already a destination with the same ID.
+func (e *Edge) AddDestinationById(ids ...string) {
+	dests := map[string]struct{}{}
+	for _, id := range e.To {
+		dests[id] = struct{}{}
+	}
+
+	for _, id := range ids {
+		if _, ok := dests[id]; ok {
+			continue
+		}
+		dests[id] = struct{}{}
+		e.To = append(e.To, id)
+	}
+}

--- a/pkg/sbom/edge_test.go
+++ b/pkg/sbom/edge_test.go
@@ -1,0 +1,28 @@
+package sbom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddDestinationById(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		sut    *Edge
+		dest   []string
+		expLen int
+	}{
+		{"add1", &Edge{To: []string{}}, []string{"test"}, 1},
+		{"dedupe", &Edge{To: []string{"test"}}, []string{"test"}, 1},
+		{"dedupe-with-existing", &Edge{To: []string{"test", "test2"}}, []string{"test"}, 2},
+		{"dedupe-more-than-1", &Edge{To: []string{"test", "test2"}}, []string{"test2", "test"}, 2},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.sut.AddDestinationById(tc.dest...)
+			require.Equal(t, tc.expLen, len(tc.sut.To))
+		})
+	}
+}

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -666,7 +666,7 @@ func (nl *NodeList) RelateNodeListAtID(nl2 *NodeList, nodeID string, edgeType Ed
 		nl.Edges = append(nl.Edges, edge)
 	} else {
 		// Perhaps we should filter these
-		edge.To = append(edge.To, nl2.RootElements...)
+		edge.AddDestinationById(nl2.RootElements...)
 	}
 
 	for _, n := range nl2.Nodes {
@@ -674,6 +674,21 @@ func (nl *NodeList) RelateNodeListAtID(nl2 *NodeList, nodeID string, edgeType Ed
 			continue
 		}
 		nl.AddNode(n)
+	}
+
+	// Copy the remaining edges from n2
+	for _, e := range nl2.Edges {
+		// Check if we have an edge of the samer type already in the
+		// nodelist and if so, reuse it:
+		if _, ok := nlEdges[e.From]; ok {
+			if _, ok2 := nlEdges[e.From][e.Type]; ok2 {
+				nlEdges[e.From][e.Type][0].AddDestinationById(e.To...)
+				continue
+			}
+		}
+
+		// If the node was not found, add a copy
+		nl.Edges = append(nl.Edges, e.Copy())
 	}
 
 	return nil

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -1315,3 +1315,83 @@ func TestNodeListCopy(t *testing.T) {
 		require.True(t, tc.original.Equal(copied), "equal copied nodelist %s %s", tc.original, copied)
 	}
 }
+
+func TestRelateNodeListAtId(t *testing.T) {
+	sutId := "nodeA"
+	nodeId := "nodeB"
+	testNodeList := &NodeList{
+		RootElements: []string{sutId},
+		Nodes:        []*Node{{Id: sutId}},
+		Edges:        []*Edge{},
+	}
+
+	for _, tc := range []struct {
+		name        string
+		sut         *NodeList
+		nodeList    *NodeList
+		expected    *NodeList
+		shouldError bool
+	}{
+		{
+			// This merges these nodelists:
+			//   root        root
+			//     \           \
+			//    NodeA       NodeB
+			name: "relate to node",
+			sut:  testNodeList,
+			nodeList: &NodeList{
+				RootElements: []string{nodeId},
+				Nodes:        []*Node{{Id: nodeId}},
+				Edges:        []*Edge{},
+			},
+			expected: &NodeList{
+				RootElements: []string{sutId},
+				Nodes:        []*Node{{Id: sutId}, {Id: nodeId}},
+				Edges:        []*Edge{{From: sutId, To: []string{nodeId}, Type: Edge_ancestor}},
+			},
+		},
+		{
+			// This merges two nodelists:
+			// root         root
+			//   \            \
+			//  NodeA        NodeB
+			//                 \ (contains)
+			//                NodeC
+			name: "relate with descendants",
+			sut:  testNodeList,
+			nodeList: &NodeList{
+				RootElements: []string{nodeId},
+				Nodes:        []*Node{{Id: nodeId}, {Id: "nodeC"}},
+				Edges:        []*Edge{{From: nodeId, To: []string{"nodeC"}, Type: Edge_contains}},
+			},
+			expected: &NodeList{
+				RootElements: []string{sutId},
+				Nodes:        []*Node{{Id: sutId}, {Id: nodeId}, {Id: "nodeC"}},
+				Edges: []*Edge{
+					{From: sutId, To: []string{nodeId}, Type: Edge_ancestor},
+					{From: nodeId, To: []string{"nodeC"}, Type: Edge_contains},
+				},
+			},
+		},
+		{
+			// Error when the specified ID is not there
+			name: "merge point not available",
+			sut: &NodeList{
+				RootElements: []string{"nodeC"},
+				Nodes:        []*Node{{Id: "nodeC"}},
+			},
+			nodeList:    testNodeList,
+			shouldError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.sut.RelateNodeListAtID(tc.nodeList, sutId, Edge_ancestor)
+			if tc.shouldError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Truef(t, tc.sut.Equal(tc.expected), "Result: %+v", tc.sut)
+		})
+	}
+}


### PR DESCRIPTION
This commit fixes a bug that was causing edges from the source NodeList
to be lost when calling `nodelist.RelateNodeAtID()`.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@stacklok.com>