### PR TITLE
Backend interface update

### DIFF
--- a/pkg/reader/options.go
+++ b/pkg/reader/options.go
@@ -70,7 +70,7 @@ func WithSniffer(s Sniffer) ReaderOption {
 	}
 }
 
-func WithStoreRetriever(sb storage.StoreRetriever[sbom.Document]) ReaderOption {
+func WithStoreRetriever(sb storage.Backend[*sbom.Document]) ReaderOption {
 	return func(r *Reader) {
 		if sb != nil {
 			r.Storage = sb

--- a/pkg/reader/options.go
+++ b/pkg/reader/options.go
@@ -70,7 +70,7 @@ func WithSniffer(s Sniffer) ReaderOption {
 	}
 }
 
-func WithStoreRetriever(sb storage.Backend[*sbom.Document]) ReaderOption {
+func WithStoreRetriever(sb storage.StoreRetriever[*sbom.Document]) ReaderOption {
 	return func(r *Reader) {
 		if sb != nil {
 			r.Storage = sb

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -60,7 +60,7 @@ func GetFormatUnserializer(format formats.Format) (native.Unserializer, error) {
 
 type Reader struct {
 	sniffer Sniffer
-	Storage storage.StoreRetriever[sbom.Document]
+	Storage storage.Backend[*sbom.Document]
 	Options *Options
 }
 

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -60,7 +60,7 @@ func GetFormatUnserializer(format formats.Format) (native.Unserializer, error) {
 
 type Reader struct {
 	sniffer Sniffer
-	Storage storage.Backend[*sbom.Document]
+	Storage storage.StoreRetriever[*sbom.Document]
 	Options *Options
 }
 

--- a/pkg/storage/backend.go
+++ b/pkg/storage/backend.go
@@ -25,8 +25,12 @@ type (
 		Retrieve(string, *RetrieveOptions) (T, error)
 	}
 
-	Backend[T ProtobomType] interface {
+	StoreRetriever[T ProtobomType] interface {
 		Storer[T]
 		Retriever[T]
+	}
+
+	Backend[T ProtobomType] interface {
+		StoreRetriever[T]
 	}
 )

--- a/pkg/storage/backend.go
+++ b/pkg/storage/backend.go
@@ -12,17 +12,21 @@ import (
 
 type (
 	ProtobomType interface {
-		sbom.Document | sbom.DocumentType | sbom.Edge | sbom.ExternalReference |
-			sbom.Metadata | sbom.Node | sbom.NodeList | sbom.Person | sbom.Purpose | sbom.Tool |
+		*sbom.Document | *sbom.DocumentType | *sbom.Edge | *sbom.ExternalReference |
+			*sbom.Metadata | *sbom.Node | *sbom.NodeList | *sbom.Person | *sbom.Purpose | *sbom.Tool |
 			map[sbom.HashAlgorithm]string | map[sbom.SoftwareIdentifierType]string
 	}
 
-	StoreRetriever[T ProtobomType] interface {
-		Store(*T, *StoreOptions) error
-		Retrieve(string, *RetrieveOptions) (*T, error)
+	Storer[T ProtobomType] interface {
+		Store(T, *StoreOptions) error
+	}
+
+	Retriever[T ProtobomType] interface {
+		Retrieve(string, *RetrieveOptions) (T, error)
 	}
 
 	Backend[T ProtobomType] interface {
-		StoreRetriever[T]
+		Storer[T]
+		Retriever[T]
 	}
 )

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/release-utils/util"
 )
 
-var _ StoreRetriever[sbom.Document] = (*FileSystem)(nil)
+var _ Backend[*sbom.Document] = (*FileSystem)(nil)
 
 type FileSystemOptions struct {
 	// Path is the path top the directory where the storage

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/release-utils/util"
 )
 
-var _ Backend[*sbom.Document] = (*FileSystem)(nil)
+var _ StoreRetriever[*sbom.Document] = (*FileSystem)(nil)
 
 type FileSystemOptions struct {
 	// Path is the path top the directory where the storage

--- a/pkg/writer/options.go
+++ b/pkg/writer/options.go
@@ -39,7 +39,7 @@ func WithFormat(f formats.Format) WriterOption {
 	}
 }
 
-func WithStoreRetriever(sb storage.StoreRetriever[sbom.Document]) WriterOption {
+func WithStoreRetriever(sb storage.Backend[*sbom.Document]) WriterOption {
 	return func(w *Writer) {
 		if sb != nil {
 			w.Storage = sb

--- a/pkg/writer/options.go
+++ b/pkg/writer/options.go
@@ -39,7 +39,7 @@ func WithFormat(f formats.Format) WriterOption {
 	}
 }
 
-func WithStoreRetriever(sb storage.Backend[*sbom.Document]) WriterOption {
+func WithStoreRetriever(sb storage.StoreRetriever[*sbom.Document]) WriterOption {
 	return func(w *Writer) {
 		if sb != nil {
 			w.Storage = sb

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Writer struct {
-	Storage storage.Backend[*sbom.Document]
+	Storage storage.StoreRetriever[*sbom.Document]
 	Options *Options
 }
 

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Writer struct {
-	Storage storage.StoreRetriever[sbom.Document]
+	Storage storage.Backend[*sbom.Document]
 	Options *Options
 }
 


### PR DESCRIPTION
This PR is a minor update to the recently added `StoreRetriever` interface and the `ProtobomType` type constraint.

- Add separate `Storer` and `Retriever` interfaces that `StoreRetriever` embeds
  - This enables backends to create types that only implement one behavior or the other if desired
  - `Backend` definition unchanged
- For the struct types that comprise the `ProtobomType` type constraint, change to pointer types (e.g. `sbom.Node` --> `*sbom.Node`), but leave maps as-is
  - A map is already a reference, so implementing methods for `*map[sbom.HashAlgorithm]string` and `*map[sbom.SoftwareIdentifierType]string` causes issues with dereferencing