### PR TITLE
Revert StoreRetriever to only accept Document

### DIFF
--- a/pkg/reader/options.go
+++ b/pkg/reader/options.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/protobom/protobom/pkg/native"
-	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/protobom/protobom/pkg/storage"
 )
 
@@ -70,7 +69,7 @@ func WithSniffer(s Sniffer) ReaderOption {
 	}
 }
 
-func WithStoreRetriever(sb storage.StoreRetriever[*sbom.Document]) ReaderOption {
+func WithStoreRetriever(sb storage.StoreRetriever) ReaderOption {
 	return func(r *Reader) {
 		if sb != nil {
 			r.Storage = sb

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -60,7 +60,7 @@ func GetFormatUnserializer(format formats.Format) (native.Unserializer, error) {
 
 type Reader struct {
 	sniffer Sniffer
-	Storage storage.StoreRetriever[*sbom.Document]
+	Storage storage.StoreRetriever
 	Options *Options
 }
 

--- a/pkg/storage/backend.go
+++ b/pkg/storage/backend.go
@@ -22,7 +22,7 @@ type (
 	Nodes              = []Node
 	Person             = *sbom.Person
 	Persons            = []Person
-	Purpose            = sbom.Purpose
+	Purpose            = *sbom.Purpose
 	Purposes           = []Purpose
 	Tool               = *sbom.Tool
 	Tools              = []Tool

--- a/pkg/storage/backend.go
+++ b/pkg/storage/backend.go
@@ -9,51 +9,20 @@ package storage
 import "github.com/protobom/protobom/pkg/sbom"
 
 type (
-	Document           = *sbom.Document
-	DocumentType       = *sbom.DocumentType
-	DocumentTypes      = []DocumentType
-	Edge               = *sbom.Edge
-	Edges              = []Edge
-	ExternalReference  = *sbom.ExternalReference
-	ExternalReferences = []ExternalReference
-	Metadata           = *sbom.Metadata
-	Node               = *sbom.Node
-	NodeList           = *sbom.NodeList
-	Nodes              = []Node
-	Person             = *sbom.Person
-	Persons            = []Person
-	Purpose            = *sbom.Purpose
-	Purposes           = []Purpose
-	Tool               = *sbom.Tool
-	Tools              = []Tool
-
-	ProtobomType interface {
-		Document | Metadata | NodeList |
-			DocumentType | DocumentTypes |
-			Edge | Edges |
-			ExternalReference | ExternalReferences |
-			Node | Nodes |
-			Person | Persons |
-			Purpose | Purposes |
-			Tool | Tools |
-			map[sbom.HashAlgorithm]string |
-			map[sbom.SoftwareIdentifierType]string
+	Storer interface {
+		Store(*sbom.Document, *StoreOptions) error
 	}
 
-	Storer[T ProtobomType] interface {
-		Store(T, *StoreOptions) error
+	Retriever interface {
+		Retrieve(string, *RetrieveOptions) (*sbom.Document, error)
 	}
 
-	Retriever[T ProtobomType] interface {
-		Retrieve(string, *RetrieveOptions) (T, error)
+	StoreRetriever interface {
+		Storer
+		Retriever
 	}
 
-	StoreRetriever[T ProtobomType] interface {
-		Storer[T]
-		Retriever[T]
-	}
-
-	Backend[T ProtobomType] interface {
-		StoreRetriever[T]
+	Backend interface {
+		StoreRetriever
 	}
 )

--- a/pkg/storage/backend.go
+++ b/pkg/storage/backend.go
@@ -6,15 +6,38 @@
 
 package storage
 
-import (
-	"github.com/protobom/protobom/pkg/sbom"
-)
+import "github.com/protobom/protobom/pkg/sbom"
 
 type (
+	Document           = *sbom.Document
+	DocumentType       = *sbom.DocumentType
+	DocumentTypes      = []DocumentType
+	Edge               = *sbom.Edge
+	Edges              = []Edge
+	ExternalReference  = *sbom.ExternalReference
+	ExternalReferences = []ExternalReference
+	Metadata           = *sbom.Metadata
+	Node               = *sbom.Node
+	NodeList           = *sbom.NodeList
+	Nodes              = []Node
+	Person             = *sbom.Person
+	Persons            = []Person
+	Purpose            = sbom.Purpose
+	Purposes           = []Purpose
+	Tool               = *sbom.Tool
+	Tools              = []Tool
+
 	ProtobomType interface {
-		*sbom.Document | *sbom.DocumentType | *sbom.Edge | *sbom.ExternalReference |
-			*sbom.Metadata | *sbom.Node | *sbom.NodeList | *sbom.Person | *sbom.Purpose | *sbom.Tool |
-			map[sbom.HashAlgorithm]string | map[sbom.SoftwareIdentifierType]string
+		Document | Metadata | NodeList |
+			DocumentType | DocumentTypes |
+			Edge | Edges |
+			ExternalReference | ExternalReferences |
+			Node | Nodes |
+			Person | Persons |
+			Purpose | Purposes |
+			Tool | Tools |
+			map[sbom.HashAlgorithm]string |
+			map[sbom.SoftwareIdentifierType]string
 	}
 
 	Storer[T ProtobomType] interface {

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/release-utils/util"
 )
 
-var _ StoreRetriever[*sbom.Document] = (*FileSystem)(nil)
+var _ StoreRetriever = (*FileSystem)(nil)
 
 type FileSystemOptions struct {
 	// Path is the path top the directory where the storage

--- a/pkg/writer/options.go
+++ b/pkg/writer/options.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/protobom/protobom/pkg/native"
-	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/protobom/protobom/pkg/storage"
 )
 
@@ -39,7 +38,7 @@ func WithFormat(f formats.Format) WriterOption {
 	}
 }
 
-func WithStoreRetriever(sb storage.StoreRetriever[*sbom.Document]) WriterOption {
+func WithStoreRetriever(sb storage.StoreRetriever) WriterOption {
 	return func(w *Writer) {
 		if sb != nil {
 			w.Storage = sb

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Writer struct {
-	Storage storage.StoreRetriever[*sbom.Document]
+	Storage storage.StoreRetriever
 	Options *Options
 }
 


### PR DESCRIPTION
In addition to the current protobom types in the type constraint, this PR allows for implementing `Storer` and `Retriever` for **_slices_** of certain of those types. For example:

```go
// Store implements the Storer interface for *sbom.Node.
func (backend *NodeBackend) Store(n *sbom.Node, opts *storage.StoreOptions) error {
	//
}

// Retrieve implements the Retriever interface for *sbom.Node.
func (backend *NodeBackend) Retrieve(id string, opts *storage.RetrieveOptions) (*sbom.Node, error) {
	//
}
```

as well as

```go
// Store implements the Storer interface for []*sbom.Node.
func (backend *NodesBackend) Store(n []*sbom.Node, opts *storage.StoreOptions) error {
	//
}

// Retrieve implements the Retriever interface for []*sbom.Node.
func (backend *NodesBackend) Retrieve(id string, opts *storage.RetrieveOptions) ([]*sbom.Node, error) {
	//
}
```

This is primarily for use with `Retrieve` so that given an ID, the method can return a slice of all objects associated with that ID, but with an added bonus for `Store`: with the ability to accept a slice of objects, `Store` will be able to insert all ent objects into the database in one bulk transaction, which should be a significant performance improvement over inserting them one at a time.