### PR TITLE
Formalize SPDX 2.3 namespace behavior

### DIFF
--- a/docs/options/README.md
+++ b/docs/options/README.md
@@ -1,0 +1,8 @@
+# Serializer and Unserializer Options
+
+Each native format serializer supports options that control how protobom behaves
+when reading and writing SBOM formats.
+
+### [Serializer Options](serializers/)
+
+### Unserializer Options

--- a/docs/options/serializers/README.md
+++ b/docs/options/serializers/README.md
@@ -1,0 +1,5 @@
+# Serializer Options
+
+The following serializers have documented options. 
+
+* [SPDX 2.3](spdx23.md)

--- a/docs/options/serializers/spdx23.md
+++ b/docs/options/serializers/spdx23.md
@@ -1,0 +1,10 @@
+# SPDX 2.3 Serializer Options
+
+The following options are supported by the SPDX 2.3 serializer
+
+Options Type: `serializers.SPDX23Options`
+
+| Option | Type | Default | Description
+| --- | --- | --- | --- |
+| `FailOnInvalidDocIdFragment` | `bool` | `false` | FailOnInvalidDocIdFragment makes the serializer return an error if the document ID has a fragment but  t is not set to "SPDXRef-Document". |
+| `GenerateDocumentId` | `bool` | `true` | // GenerateDocumentId causes the serializer to generate a non-deterministic document ID when a protobom doesn't have one defined. |

--- a/pkg/native/serializers/serializer_spdx23_test.go
+++ b/pkg/native/serializers/serializer_spdx23_test.go
@@ -63,7 +63,7 @@ func TestExtRefTypeFromProtobomExtRef(t *testing.T) {
 	}
 }
 
-func TestSpdxNamespaceFromProtobomId(t *testing.T) {
+func TestSpdxNamespaceFromProtobomID(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		sut      string

--- a/pkg/native/serializers/serializer_spdx23_test.go
+++ b/pkg/native/serializers/serializer_spdx23_test.go
@@ -62,3 +62,89 @@ func TestExtRefTypeFromProtobomExtRef(t *testing.T) {
 		})
 	}
 }
+
+func TestSpdxNamespaceFromProtobomId(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		sut      string
+		expected string
+		options  SPDX23Options
+		mustErr  bool
+	}{
+		{
+			name:     "plain-uri-no-fragment",
+			sut:      "https://spdx.org/spdxdocs/28b3c8c8-687c-4df5-9744-ee8e7d644392",
+			expected: "https://spdx.org/spdxdocs/28b3c8c8-687c-4df5-9744-ee8e7d644392",
+			options:  DefaultSPDX23Options,
+			mustErr:  false,
+		},
+		{
+			name:     "plain-uri-valid-fragment",
+			sut:      "https://spdx.org/spdxdocs/48ddaa40-309a-40f7-8a8a-643a2262b144#SPDXRef-DOCUMENT",
+			expected: "https://spdx.org/spdxdocs/48ddaa40-309a-40f7-8a8a-643a2262b144",
+			options:  DefaultSPDX23Options,
+			mustErr:  false,
+		},
+		{
+			name:    "plain-uri-valid-fragment-fail",
+			sut:     "https://spdx.org/spdxdocs/48ddaa40-309a-40f7-8a8a-643a2262b144#OtherRef",
+			options: SPDX23Options{FailOnInvalidDocIdFragment: true},
+			mustErr: true,
+		},
+		{
+			name:     "plain-uri-valid-fragment-nofail",
+			sut:      "https://spdx.org/spdxdocs/48ddaa40-309a-40f7-8a8a-643a2262b144#OtherRef",
+			expected: "https://spdx.org/spdxdocs/48ddaa40-309a-40f7-8a8a-643a2262b144",
+			options:  SPDX23Options{FailOnInvalidDocIdFragment: false},
+			mustErr:  false,
+		},
+		{
+			name:     "urn",
+			sut:      "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+			expected: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+			options:  DefaultSPDX23Options,
+			mustErr:  false,
+		},
+		{
+			name:     "random-string",
+			sut:      "yolo",
+			expected: "yolo",
+			options:  DefaultSPDX23Options,
+			mustErr:  false,
+		},
+		{
+			name:     "package-url",
+			sut:      "pkg:npm/%40angular/animation@12.3.1",
+			expected: "pkg:npm/%40angular/animation@12.3.1",
+			options:  DefaultSPDX23Options,
+			mustErr:  false,
+		},
+		{
+			name:    "blank-url-fail",
+			sut:     "",
+			options: SPDX23Options{GenerateDocumentID: false},
+			mustErr: true,
+		},
+		{
+			name:     "blank-url",
+			sut:      "",
+			expected: "*",
+			options:  DefaultSPDX23Options,
+			mustErr:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := spdxNamespaceFromProtobomID(tc.options, tc.sut)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.expected == "*" {
+				require.NotEmpty(t, r)
+			} else {
+				require.Equal(t, tc.expected, r)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit modifies the SPDX namespace behavior when serializing documents. This change properly handles the URL fragments when writing the SPDX document, stripping it from the doc when defined. It also ensures that other valid URIs such as urns and package URLs can be piped and used as valid namespaces.

The PR introduces two options into the serializer to ensure that we can control when things go wrong: `FailOnInvalidDocIdFragment` and `GenerateDocumentId`, documentation for the serializer options is included as well as a unit test.

Signed-off-by: Adolfo García Veytia (puerco) <puerco@stacklok.com>
