### PR TITLE
Protobom mods

### DIFF
--- a/pkg/mod/mod.go
+++ b/pkg/mod/mod.go
@@ -1,0 +1,11 @@
+// --------------------------------------------------------------
+// SPDX-FileCopyrightText: Copyright 2024 The Protobom Authors
+// SPDX-License-Identifier: Apache-2.0
+// --------------------------------------------------------------
+
+// Package mod defines constant strings that represent a custom behavior in
+// protobom. Mods behave like feature flags, enabling features in the writer
+// and reader only when requested.
+package mod
+
+type Mod string

--- a/pkg/native/serializer.go
+++ b/pkg/native/serializer.go
@@ -5,6 +5,7 @@ package native
 import (
 	"io"
 
+	"github.com/protobom/protobom/pkg/mod"
 	"github.com/protobom/protobom/pkg/sbom"
 )
 
@@ -18,4 +19,6 @@ type RenderOptions struct {
 	Indent int
 }
 
-type SerializeOptions struct{}
+type SerializeOptions struct {
+	Mods map[mod.Mod]struct{}
+}

--- a/pkg/native/unserializer.go
+++ b/pkg/native/unserializer.go
@@ -5,6 +5,7 @@ package native
 import (
 	"io"
 
+	"github.com/protobom/protobom/pkg/mod"
 	"github.com/protobom/protobom/pkg/sbom"
 )
 
@@ -13,4 +14,6 @@ type Unserializer interface {
 	Unserialize(io.Reader, *UnserializeOptions, interface{}) (*sbom.Document, error)
 }
 
-type UnserializeOptions struct{}
+type UnserializeOptions struct {
+	Mods map[mod.Mod]struct{}
+}

--- a/pkg/reader/options.go
+++ b/pkg/reader/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/protobom/protobom/pkg/formats"
+	"github.com/protobom/protobom/pkg/mod"
 	"github.com/protobom/protobom/pkg/native"
 	"github.com/protobom/protobom/pkg/storage"
 )
@@ -82,5 +83,17 @@ func WithRetrieveOptions(ro *storage.RetrieveOptions) ReaderOption {
 		if ro != nil {
 			r.Options.RetrieveOptions = ro
 		}
+	}
+}
+
+func WithMod(m mod.Mod) ReaderOption {
+	return func(r *Reader) {
+		r.Options.UnserializeOptions.Mods[m] = struct{}{}
+	}
+}
+
+func WithoutMod(m mod.Mod) ReaderOption {
+	return func(r *Reader) {
+		delete(r.Options.UnserializeOptions.Mods, m)
 	}
 }

--- a/pkg/writer/options.go
+++ b/pkg/writer/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/protobom/protobom/pkg/formats"
+	"github.com/protobom/protobom/pkg/mod"
 	"github.com/protobom/protobom/pkg/native"
 	"github.com/protobom/protobom/pkg/storage"
 )
@@ -51,6 +52,18 @@ func WithStoreOptions(ro *storage.StoreOptions) WriterOption {
 		if ro != nil {
 			w.Options.StoreOptions = ro
 		}
+	}
+}
+
+func WithMod(m mod.Mod) WriterOption {
+	return func(w *Writer) {
+		w.Options.SerializeOptions.Mods[m] = struct{}{}
+	}
+}
+
+func WithoutMod(m mod.Mod) WriterOption {
+	return func(w *Writer) {
+		delete(w.Options.SerializeOptions.Mods, m)
 	}
 }
 


### PR DESCRIPTION
This PR introduces protobom _mods_. 

A _mod_ is a flag that enables a custom behavior in protobom which breaks the universal document model but is nevertheless implemented as it models a solution to an edge case or a common SBOM practice.

Mods are gated so they are only activated when an application requests them. The protobom mods are activated in the reader and writer and are enabled as properties of the serializer and unserializer options.

This PR adds functional arguments to enable and disable them at construction time. The mod package is checked in but it's empty. The first mod we'll add will be the "cdx properties to SPDX annotations" solution that will soon follow this PR.