### PR TITLE
fix: set sbom reader options.Format to be available in downstream code

### DIFF
--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -118,16 +118,15 @@ func (r *Reader) ParseStreamWithOptions(f io.ReadSeeker, o *Options) (*sbom.Docu
 		return nil, fmt.Errorf("options cannot be nil")
 	}
 
-	format := o.Format
 	if o.Format == "" {
 		f, err := r.detectFormat(f)
 		if err != nil {
 			return nil, fmt.Errorf("detecting SBOM format: %w", err)
 		}
-		format = f
+		o.Format = f
 	}
 
-	unserializer, err := GetFormatUnserializer(format)
+	unserializer, err := GetFormatUnserializer(o.Format)
 	if err != nil {
 		return nil, fmt.Errorf("getting format parser: %w", err)
 	}


### PR DESCRIPTION
Small change to capture document format in sbomReader options to be consumable later. 

example: (current behavior)
```
sbomReader := reader.New()

document, err := sbomReader.ParseStream(bytes.NewReader(sbomData))
if err != nil {
return nil, fmt.Errorf("parsing SBOM data: %w", err)
}

fmt.Println(sbomReader.Options.Format.Type())
```

The Println statement at the end will always return an empty string if the format was not set in the reader options. 

Updated Behavior:
- If o.Format is set, then it will be used with `GetFormatUnserializer` 
- if o.Format is NOT set, we call `detectFormat` and set o.Format to the result and continue on to `GetFormatUnserializer` 

Side effect: This change would allow format information to be accessed later. In the above example, the println would not be empty. 
