### PR TITLE
Fix panic in WithMod when initializing

### DIFF
--- a/pkg/reader/options.go
+++ b/pkg/reader/options.go
@@ -88,6 +88,11 @@ func WithRetrieveOptions(ro *storage.RetrieveOptions) ReaderOption {
 
 func WithMod(m mod.Mod) ReaderOption {
 	return func(r *Reader) {
+		if r.Options.UnserializeOptions.Mods == nil {
+			r.Options.UnserializeOptions.Mods = map[mod.Mod]struct{}{m: {}}
+			return
+		}
+
 		r.Options.UnserializeOptions.Mods[m] = struct{}{}
 	}
 }

--- a/pkg/writer/options.go
+++ b/pkg/writer/options.go
@@ -57,6 +57,10 @@ func WithStoreOptions(ro *storage.StoreOptions) WriterOption {
 
 func WithMod(m mod.Mod) WriterOption {
 	return func(w *Writer) {
+		if w.Options.SerializeOptions.Mods == nil {
+			w.Options.SerializeOptions.Mods = map[mod.Mod]struct{}{m: {}}
+			return
+		}
 		w.Options.SerializeOptions.Mods[m] = struct{}{}
 	}
 }


### PR DESCRIPTION
This PR fixes a panic when using the `WithMod` functional option for the first time in the reader and the writer.