### PR TITLE
Support properties in annotations through SPDX mod :tada: 

### DIFF
--- a/pkg/mod/mod.go
+++ b/pkg/mod/mod.go
@@ -9,3 +9,12 @@
 package mod
 
 type Mod string
+
+// SPDX_RENDER_PROPERTIES_IN_ANNOTATIONS is a mod that cuases the SPDX serializers
+// to render the protobom property bags as annotations in SPDX.
+//
+// When enabled, protobom will marshall the property proto value into JSON and
+// add they will be rendered into an SPDX annotation in the comment field. The
+// property annotator will be fixed to protobom - v1.0.0 to make it identifiable
+// when reading them back.
+const SPDX_RENDER_PROPERTIES_IN_ANNOTATIONS = Mod("SPDX_RENDER_PROPERTIES")

--- a/pkg/native/serializer.go
+++ b/pkg/native/serializer.go
@@ -22,3 +22,9 @@ type RenderOptions struct {
 type SerializeOptions struct {
 	Mods map[mod.Mod]struct{}
 }
+
+// IsModEnabled returns true when the passed mod is enabled in the options set.
+func (so *SerializeOptions) IsModEnabled(m mod.Mod) bool {
+	_, ok := so.Mods[m]
+	return ok
+}

--- a/pkg/native/serializers/serializer_spdx23_test.go
+++ b/pkg/native/serializers/serializer_spdx23_test.go
@@ -1,10 +1,14 @@
 package serializers
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/protobom/protobom/pkg/mod"
+	"github.com/protobom/protobom/pkg/native"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/spdx/v2/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -144,6 +148,82 @@ func TestSpdxNamespaceFromProtobomID(t *testing.T) {
 				require.NotEmpty(t, r)
 			} else {
 				require.Equal(t, tc.expected, r)
+			}
+		})
+	}
+}
+
+func TestPropertiesMod(t *testing.T) {
+	propertyData := []struct {
+		name string
+		data string
+	}{
+		{"test A", "this is data A"},
+		{"test B", "this is the second value"},
+	}
+	doc := sbom.NewDocument()
+	n := sbom.NewNode()
+	n.Id = "24cc905f-da4a-401d-8f0e-4b1b29246259"
+
+	// Add properties to the node
+	for _, pd := range propertyData {
+		p := sbom.NewProperty()
+		p.Name = pd.name
+		p.Data = pd.data
+		n.Properties = append(n.Properties, p)
+	}
+
+	doc.NodeList.AddRootNode(n)
+	s := NewSPDX23()
+	for _, tc := range []struct {
+		name                string
+		serializeopts       *native.SerializeOptions
+		spdxopts            SPDX23Options
+		annotationsExpected bool
+		mustErr             bool
+	}{
+		{
+			name: "no-annotations",
+			serializeopts: &native.SerializeOptions{
+				Mods: map[mod.Mod]struct{}{},
+			},
+			annotationsExpected: false,
+		},
+		{
+			name: "annotations",
+			serializeopts: &native.SerializeOptions{
+				Mods: map[mod.Mod]struct{}{
+					mod.SPDX_RENDER_PROPERTIES_IN_ANNOTATIONS: {},
+				},
+			},
+			annotationsExpected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			packages, err := s.buildPackages(
+				tc.serializeopts, SPDX23Options{}, doc,
+			)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.Len(t, packages, 1)
+			if !tc.annotationsExpected {
+				require.Len(t, packages[0].Annotations, 0)
+				return
+			}
+			require.Len(t, packages[0].Annotations, 2)
+			for i, a := range packages[0].Annotations {
+				protoProp := sbom.NewProperty()
+				require.NoError(t, json.Unmarshal([]byte(a.AnnotationComment), protoProp))
+				require.Equal(t, propertyData[i].name, protoProp.Name)
+				require.Equal(t, propertyData[i].data, protoProp.Data)
+				require.Equal(t, common.ElementID(n.Id), packages[0].Annotations[i].AnnotationSPDXIdentifier.ElementRefID)
+				// We always set the date to unixtime 0 to make the annotation reproducible
+				require.Equal(t, "1970-01-01T00:00:00Z", packages[0].Annotations[i].AnnotationDate)
+				require.Equal(t, "Tool", packages[0].Annotations[i].Annotator.AnnotatorType)
+				require.Equal(t, "protobom - v1.0.0", packages[0].Annotations[i].Annotator.Annotator)
+				require.Equal(t, "OTHER", packages[0].Annotations[i].AnnotationType)
 			}
 		})
 	}

--- a/pkg/native/unserializer.go
+++ b/pkg/native/unserializer.go
@@ -17,3 +17,9 @@ type Unserializer interface {
 type UnserializeOptions struct {
 	Mods map[mod.Mod]struct{}
 }
+
+// IsModEnabled returns true when the passed mod is enabled in the options set.
+func (uo *UnserializeOptions) IsModEnabled(m mod.Mod) bool {
+	_, ok := uo.Mods[m]
+	return ok
+}


### PR DESCRIPTION
Now that support for the protobom mods has merged (ref https://github.com/protobom/protobom/pull/264) this PR introduces the first mod: `SPDX_RENDER_PROPERTIES_IN_ANNOTATIONS`. 

This mod causes the protobom annotations to be rendered as a json struct of the property proto embedded in the SPDX annotations of the resulting package. To enable, initialize a writer with the mod and render the protobom to SPDX 2.3:

```golang
w := writer.New(
    writer.WithMod(mod.SPDX_RENDER_PROPERTIES_IN_ANNOTATIONS),
    writer.WithFormat(formats.SPDX23JSON),
)
w.WriteStream(doc, os.Stdout)
```
(Note that the code example requires https://github.com/protobom/protobom/pull/275 which fixes a bug that causes the options to panic)

### Output Example

Here's an example SBOM with properties rendered as annotations:

```json
{
    "spdxVersion": "SPDX-2.3",
    "dataLicense": "CC0-1.0",
    "SPDXID": "SPDXRef-DOCUMENT",
    "name": "test",
    "documentNamespace": "https://spdx.org/spdxdocs/protobom/e420abd0-52e8-4689-b161-0c2c35eda4ec",
    "creationInfo": {
        "licenseListVersion": "3.20",
        "creators": [
            "Tool: protobom-devel"
        ],
        "created": "2024-10-27T18:32:00Z"
    },
    "packages": [
        {
            "name": "test-package",
            "SPDXID": "SPDXRef-24cc905f-da4a-401d-8f0e-4b1b29246259",
            "downloadLocation": "NOASSERTION",
            "filesAnalyzed": false,
            "annotations": [
                {
                    "annotator": "Tool: protobom - v1.0.0",
                    "annotationDate": "1970-01-01T00:00:00Z",
                    "annotationType": "OTHER",
                    "comment": "{\"name\":\"test A\",\"data\":\"this is data A\"}"
                },
                {
                    "annotator": "Tool: protobom - v1.0.0",
                    "annotationDate": "1970-01-01T00:00:00Z",
                    "annotationType": "OTHER",
                    "comment": "{\"name\":\"test B\",\"data\":\"this is the second value\"}"
                }
            ]
        }
    ],
    "relationships": [
        {
            "spdxElementId": "SPDXRef-DOCUMENT",
            "relatedSpdxElement": "SPDXRef-24cc905f-da4a-401d-8f0e-4b1b29246259",
            "relationshipType": "DESCRIBES"
        }
    ]
}
````
The resulting document is valid SPDX:
```
java -jar tools-java-1.1.8-jar-with-dependencies.jar  Verify test-annotation.spdx.json 
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
This SPDX Document is valid.
``` 

A test is included to verify and lock the rendering of the mod.

Still TODO: Rebuild the properties from the json when reading docs.