### PR TITLE
Support for SBOM data sinks

### DIFF
--- a/pkg/datasink/listener.go
+++ b/pkg/datasink/listener.go
@@ -1,0 +1,16 @@
+// package datasink exposes objects and methods to tap into the SBOM data flow
+// inside of the reader and writer libraries. Interested parties can register
+// listeners that can tap into SBOM data as it is being read and written to
+// the main stream.
+package datasink
+
+import "io"
+
+// Listener is the simplest datasink. It just wraps `io.Writer`. It is an
+// interface that lets objects interested in tapping into the reader or writer
+// IO streams. When a Listener is plugged into the reader, all the data read
+// in from the reader or written from the witer will also be piped to sink's
+// Write() method.
+type Listener interface {
+	io.Writer
+}

--- a/pkg/reader/options.go
+++ b/pkg/reader/options.go
@@ -3,6 +3,7 @@ package reader
 import (
 	"fmt"
 
+	"github.com/protobom/protobom/pkg/datasink"
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/protobom/protobom/pkg/mod"
 	"github.com/protobom/protobom/pkg/native"
@@ -11,6 +12,7 @@ import (
 
 type Options struct {
 	Format             formats.Format
+	Listeners          []datasink.Listener
 	UnserializeOptions *native.UnserializeOptions
 	RetrieveOptions    *storage.RetrieveOptions
 	formatOptions      map[string]interface{}
@@ -100,5 +102,11 @@ func WithMod(m mod.Mod) ReaderOption {
 func WithoutMod(m mod.Mod) ReaderOption {
 	return func(r *Reader) {
 		delete(r.Options.UnserializeOptions.Mods, m)
+	}
+}
+
+func WithListener(l datasink.Listener) ReaderOption {
+	return func(r *Reader) {
+		r.Options.Listeners = append(r.Options.Listeners, l)
 	}
 }

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -137,8 +137,14 @@ func (r *Reader) ParseStreamWithOptions(f io.ReadSeeker, o *Options) (*sbom.Docu
 		return nil, fmt.Errorf("getting format parser: %w", err)
 	}
 
+	// Build the listening chain of all the I/O sinks
+	var stream io.Reader = f
+	for i := range o.Listeners {
+		stream = io.TeeReader(stream, o.Listeners[i])
+	}
+
 	doc, err := unserializer.Unserialize(
-		f, o.UnserializeOptions, r.Options.GetFormatOptions(unserializer),
+		stream, o.UnserializeOptions, r.Options.GetFormatOptions(unserializer),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unserializing: %w", err)

--- a/pkg/writer/options.go
+++ b/pkg/writer/options.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"fmt"
 
+	"github.com/protobom/protobom/pkg/datasink"
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/protobom/protobom/pkg/mod"
 	"github.com/protobom/protobom/pkg/native"
@@ -71,8 +72,15 @@ func WithoutMod(m mod.Mod) WriterOption {
 	}
 }
 
+func WithListener(l datasink.Listener) WriterOption {
+	return func(w *Writer) {
+		w.Options.Listeners = append(w.Options.Listeners, l)
+	}
+}
+
 type Options struct {
 	Format           formats.Format
+	Listeners        []datasink.Listener
 	RenderOptions    *native.RenderOptions
 	SerializeOptions *native.SerializeOptions
 	StoreOptions     *storage.StoreOptions

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -119,7 +119,14 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 		ro = defaultOptions.RenderOptions
 	}
 
-	if err := serializer.Render(nativeDoc, wr, ro, o.GetFormatOptions(serializer)); err != nil {
+	// Build the listening chain of all the I/O sinks
+	sinks := []io.Writer{wr}
+	for _, l := range o.Listeners {
+		sinks = append(sinks, l)
+	}
+	stream := io.MultiWriter(sinks...)
+
+	if err := serializer.Render(nativeDoc, stream, ro, o.GetFormatOptions(serializer)); err != nil {
 		return fmt.Errorf("writing rendered document to string: %w", err)
 	}
 


### PR DESCRIPTION
This PR introduces new data sink capabilities into the protobom library. Specifically, we now define a new `datasink.Listener` class that defines an object that can tap into the SBOM data stream. When registering a Listener with the reader, the listener will get a copy of all the SBOM data as it is read. The analogous also is implemented in the writer: in addition to the main data stream, any registered listeners will also get a copy of the generated SBOM data when writing.

Listeners are super easy to implement,  the interface simply wraps `io.Writer`:

```golang
type Listener interface {
	io.Writer
}
``` 

To register a new Listener, you pass anything that implements the interface through the reader and writer options, for example, to output the SBOM data to stderr as it is written to `myFile` :
```golang
w := writer.New(
       writer.WithFormat(formats.SPDX23JSON),
       writer.WithListener(os.Stderr),
)
w.WriteStream(doc, myfile)
```