### PR TITLE
Support properties/annotations mod when reading

### DIFF
--- a/pkg/mod/mod.go
+++ b/pkg/mod/mod.go
@@ -18,3 +18,10 @@ type Mod string
 // property annotator will be fixed to protobom - v1.0.0 to make it identifiable
 // when reading them back.
 const SPDX_RENDER_PROPERTIES_IN_ANNOTATIONS = Mod("SPDX_RENDER_PROPERTIES")
+
+// SPDX_READ_ANNOTATIONS_TO_PROPERTIES is a mode that causes the spdx unserializer
+// to look for protobom properties encoded in SPDX the annotations of packages.
+// When enabled, the serializer will try to unmarshal the contents of any
+// annotations by "protobom - v1.0.0" into an sbom.Property and store it in the
+// node properties.
+const SPDX_READ_ANNOTATIONS_TO_PROPERTIES = Mod("SPDX_READ_ANNOTATIONS_TO_PROPERTIES")

--- a/pkg/native/unserializers/unserializer_spdx23.go
+++ b/pkg/native/unserializers/unserializer_spdx23.go
@@ -1,6 +1,7 @@
 package unserializers
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	protospdx "github.com/protobom/protobom/pkg/formats/spdx"
+	"github.com/protobom/protobom/pkg/mod"
 	"github.com/protobom/protobom/pkg/native"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/sirupsen/logrus"
@@ -44,7 +46,7 @@ func buildDocumentIdentifier(doc *spdx23.Document) string {
 }
 
 // ParseStream reads an io.Reader to parse an SPDX 2.3 document from it
-func (u *SPDX23) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface{}) (*sbom.Document, error) {
+func (u *SPDX23) Unserialize(r io.Reader, opts *native.UnserializeOptions, _ interface{}) (*sbom.Document, error) {
 	spdxDoc, err := spdxjson.Read(r)
 	if err != nil {
 		return nil, fmt.Errorf("parsing SPDX json: %w", err)
@@ -79,7 +81,7 @@ func (u *SPDX23) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interf
 	// TODO(degradation): SPDX LicenseVersion
 
 	for _, p := range spdxDoc.Packages {
-		bom.NodeList.AddNode(u.packageToNode(p))
+		bom.NodeList.AddNode(u.packageToNode(opts, p))
 	}
 
 	for _, f := range spdxDoc.Files {
@@ -99,7 +101,7 @@ func (u *SPDX23) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interf
 }
 
 // packageToNode assigns the data from an SPDX package into a new Node
-func (u *SPDX23) packageToNode(p *spdx23.Package) *sbom.Node {
+func (u *SPDX23) packageToNode(opts *native.UnserializeOptions, p *spdx23.Package) *sbom.Node {
 	n := &sbom.Node{
 		Id:              string(p.PackageSPDXIdentifier),
 		Type:            sbom.Node_PACKAGE,
@@ -223,6 +225,23 @@ func (u *SPDX23) packageToNode(p *spdx23.Package) *sbom.Node {
 		n.Originators = []*sbom.Person{{Name: p.PackageOriginator.Originator}}
 		if p.PackageOriginator.OriginatorType == protospdx.Organization {
 			n.Originators[0].IsOrg = true
+		}
+	}
+
+	// If the hack to read properties is enabled, unmarshall any properties
+	// created by protobom:
+	if opts.IsModEnabled(mod.SPDX_READ_ANNOTATIONS_TO_PROPERTIES) {
+		for i := range p.Annotations {
+			if p.Annotations[i].Annotator.AnnotatorType != "Tool" ||
+				p.Annotations[i].Annotator.Annotator != "protobom - v1.0.0" {
+				continue
+			}
+
+			property := &sbom.Property{}
+			if err := json.Unmarshal([]byte(p.Annotations[i].AnnotationComment), property); err != nil {
+				continue
+			}
+			n.Properties = append(n.Properties, property)
 		}
 	}
 

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/protobom/protobom/pkg/formats"
+	"github.com/protobom/protobom/pkg/mod"
 	"github.com/protobom/protobom/pkg/native"
 	drivers "github.com/protobom/protobom/pkg/native/unserializers"
 	"github.com/protobom/protobom/pkg/sbom"
@@ -22,7 +23,16 @@ import (
 var (
 	regMtx                    sync.RWMutex
 	unserializers             = make(map[formats.Format]native.Unserializer)
-	defaultUnserializeOptions = &native.UnserializeOptions{}
+	defaultUnserializeOptions = &native.UnserializeOptions{
+		Mods: map[mod.Mod]struct{}{
+			// By default protobom will recognize its own annotations
+			// in SPDX files encoding properties. This is only enabled
+			// when reading. To write properties to SPDX files, enable
+			// the SPDX_RENDER_PROPERTIES_IN_ANNOTATIONS mod in the
+			// serializer options.
+			mod.SPDX_READ_ANNOTATIONS_TO_PROPERTIES: {},
+		},
+	}
 )
 
 func init() {


### PR DESCRIPTION
This PR follows up #276 and adds a new mod `SPDX_READ_ANNOTATIONS_TO_PROPERTIES` which is on by default in the reader. When enabled, the SPDX unserializer will look for annotations in packages done by `protobom - v1.0.0` and if the comment decodes to a valid property, it will register them in the node's properties.

This is the inverse of #276 which added support for the writing mod. 