### PR TITLE
fix: encode source data hash as string

### DIFF
--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -7,6 +7,7 @@ package reader
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -225,7 +226,7 @@ func setSourceData(f io.ReadSeeker, format formats.Format) (*sbom.SourceData, er
 	return &sbom.SourceData{
 		Format: string(format),
 		Hashes: map[int32]string{
-			int32(sbom.HashAlgorithm_SHA256): string(hash[:]),
+			int32(sbom.HashAlgorithm_SHA256): hex.EncodeToString(hash[:]),
 		},
 		Size: int64(docLength),
 	}, nil

--- a/pkg/reader/reader_test.go
+++ b/pkg/reader/reader_test.go
@@ -475,7 +475,7 @@ func TestReader_SetSourceData(t *testing.T) {
 			fmt:  formats.SPDX23JSON,
 			want: &sbom.SourceData{
 				Format: string(formats.SPDX23JSON),
-				Hashes: map[int32]string{3: "\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4șo\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U"},
+				Hashes: map[int32]string{3: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 				Size:   0,
 				Uri:    nil,
 			},
@@ -485,7 +485,7 @@ func TestReader_SetSourceData(t *testing.T) {
 			fmt: formats.CDX16JSON,
 			want: &sbom.SourceData{
 				Format: string(formats.CDX16JSON),
-				Hashes: map[int32]string{3: "\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4șo\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U"},
+				Hashes: map[int32]string{3: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 				Size:   0,
 				Uri:    nil,
 			},


### PR DESCRIPTION
@jhoward-lm ran into issues using the new hash field in protobom/storage. This updates `setSourceData` to encode the hash as a string. Test values also updated. 