### PR TITLE
Bump minimal go version to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/protobom/protobom
 
-go 1.22.8
+go 1.23
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2


### PR DESCRIPTION
As discussed in the feb12 community meeting, [go 1.24 has been released](https://go.dev/blog/go1.24) so we now bump the minimal supported version in the protobom core libraries to 1.23.

/cc @protobom/core-commiters 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
