### PR TITLE
Use SPDX2.3 timestamp format - `YYYY-MM-DDThh:mm:ssZ` during serialization

### DIFF
--- a/pkg/native/serializers/serializer_spdx23.go
+++ b/pkg/native/serializers/serializer_spdx23.go
@@ -412,16 +412,17 @@ func (s *SPDX23) buildPackages(
 			}
 		}
 
+		// conversion to UTC is needed as SPDX requires UTC dates
 		if node.ReleaseDate != nil {
-			p.ReleaseDate = node.ReleaseDate.String()
+			p.ReleaseDate = node.ReleaseDate.AsTime().UTC().Format(time.RFC3339)
 		}
 
 		if node.BuildDate != nil {
-			p.BuiltDate = node.BuildDate.String()
+			p.BuiltDate = node.BuildDate.AsTime().UTC().Format(time.RFC3339)
 		}
 
 		if node.ValidUntilDate != nil {
-			p.ValidUntilDate = node.ValidUntilDate.String()
+			p.ValidUntilDate = node.ValidUntilDate.AsTime().UTC().Format(time.RFC3339)
 		}
 
 		if p.PackageDownloadLocation == "" {


### PR DESCRIPTION
Protobuf output is not deterministic: https://github.com/golang/protobuf/issues/1121

Plus SPDX 2.3 docs mention that timestamps should be in a particular format. 

```
YYYY-MM-DDThh:mm:ssZ
where:

    YYYY is year
    MM is month with leading zero
    DD is day with leading zero
    T is delimiter for time
    hh is hours with leading zero in 24 hour time
    mm is minutes with leading zero
    ss is seconds with leading zero
    Z is universal time indicator
```