### PR TITLE
formats: guard the sniffer scan state against concurrent access

### DIFF
--- a/pkg/formats/sniffer.go
+++ b/pkg/formats/sniffer.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 )
 
 const (
@@ -25,6 +26,10 @@ var sniffFormats = []sniffFormat{
 }
 
 var state = make(map[string]sniffState, len(sniffFormats))
+
+// stateMu guards the package-level state map, which SniffReader reassigns
+// and the sniffers read and write while scanning a non-JSON document.
+var stateMu sync.Mutex
 
 type sniffFormat interface {
 	sniff(data []byte) Format
@@ -111,6 +116,11 @@ func (fs *Sniffer) SniffReader(f io.ReadSeeker) (Format, error) {
 	fileScanner.Split(bufio.ScanLines)
 
 	var format Format
+
+	// The scan below reads and writes the shared state map, so serialize
+	// concurrent sniffs to keep them from racing on it.
+	stateMu.Lock()
+	defer stateMu.Unlock()
 
 	initSniffState()
 	for fileScanner.Scan() {

--- a/pkg/formats/sniffer_test.go
+++ b/pkg/formats/sniffer_test.go
@@ -1,7 +1,9 @@
 package formats
 
 import (
+	"bytes"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,6 +94,28 @@ func TestSniffReader(t *testing.T) {
 		require.Equal(t, tc.formatType, sbomFormat.Type())
 		require.Equal(t, tc.version, sbomFormat.Version())
 	}
+}
+
+func TestSniffReaderConcurrent(t *testing.T) {
+	// A tag-value SPDX document falls through the JSON decode and exercises
+	// the shared, map-based line scanner. Running many sniffs at once must
+	// not race on that map. Run this with -race to catch regressions.
+	data, err := os.ReadFile("testdata/nginx.spdx")
+	require.NoError(t, err)
+
+	const workers = 50
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			fs := Sniffer{}
+			format, err := fs.SniffReader(bytes.NewReader(data))
+			require.NoError(t, err)
+			require.NotEmpty(t, format)
+		}()
+	}
+	wg.Wait()
 }
 
 func TestSniffFile(t *testing.T) {

--- a/pkg/formats/sniffer_test.go
+++ b/pkg/formats/sniffer_test.go
@@ -106,16 +106,23 @@ func TestSniffReaderConcurrent(t *testing.T) {
 	const workers = 50
 	var wg sync.WaitGroup
 	wg.Add(workers)
-	for i := 0; i < workers; i++ {
+	// Collect per-worker results and assert on them from the test goroutine:
+	// require may only be called there, since it stops the goroutine it runs in.
+	formats := make([]Format, workers)
+	errs := make([]error, workers)
+	for i := range workers {
 		go func() {
 			defer wg.Done()
 			fs := Sniffer{}
-			format, err := fs.SniffReader(bytes.NewReader(data))
-			require.NoError(t, err)
-			require.NotEmpty(t, format)
+			formats[i], errs[i] = fs.SniffReader(bytes.NewReader(data))
 		}()
 	}
 	wg.Wait()
+
+	for i := range workers {
+		require.NoError(t, errs[i])
+		require.NotEmpty(t, formats[i])
+	}
 }
 
 func TestSniffFile(t *testing.T) {


### PR DESCRIPTION
The format sniffer keeps its scan state in a package-level `state` map (`pkg/formats/sniffer.go`). `SniffReader` reassigns and writes that map on every non-JSON or malformed-JSON sniff, with no synchronization, so two concurrent detections race on it. Under concurrency this trips the race detector, and without it produces `fatal error: concurrent map writes`, which is not recoverable.

It is reachable from the default parse path: `reader.New().ParseStream(r)` with no explicit format calls `detectFormat` then `SniffReader`. Valid JSON returns on the first decode and never touches the map, but tag-value SPDX documents and any malformed or truncated JSON fall through to the map-based line scanner, so a service auto-detecting concurrent SBOM uploads that include those shapes can crash the whole process.

This guards the sniff scan with a package mutex so concurrent detections do not race, the same shape as the earlier data-race fixes #386 and #387. A `-race` test with concurrent `ParseStream` calls trips the detector before the change and is clean after. Removing the package-global state entirely would be a reasonable follow-up, but the lock is the minimal correct fix.