### PR TITLE
Fix SPDX serializer dropping packages with multiple primary purposes

### DIFF
--- a/pkg/native/serializers/serializer_spdx23.go
+++ b/pkg/native/serializers/serializer_spdx23.go
@@ -367,13 +367,7 @@ func (s *SPDX23) buildPackages(
 		if len(node.PrimaryPurpose) > 0 && (node.PrimaryPurpose[0] != sbom.Purpose_UNKNOWN_PURPOSE) {
 			// Allowed values: APPLICATION, FRAMEWORK, LIBRARY, CONTAINER, OPERATING-SYSTEM, DEVICE, FIRMWARE, SOURCE, ARCHIVE, FILE, INSTALL, OTHER
 
-			if len(node.PrimaryPurpose) > 1 {
-				// TODO(degradation): Multiple PrimaryPurpose in protobom.Node, but spdx.Package only allows single PrimaryPackagePurpose so we are using the first
-				if true { // temp workaround in favor of adding a lint tag
-					break
-				}
-			}
-
+			// TODO(degradation): Multiple PrimaryPurpose in protobom.Node, but spdx.Package only allows single PrimaryPackagePurpose so we are using the first
 			switch node.PrimaryPurpose[0] {
 			case sbom.Purpose_APPLICATION, sbom.Purpose_EXECUTABLE:
 				p.PrimaryPackagePurpose = "APPLICATION"

--- a/pkg/native/serializers/serializer_spdx23_test.go
+++ b/pkg/native/serializers/serializer_spdx23_test.go
@@ -380,6 +380,42 @@ func TestBuildPackages(t *testing.T) {
 			},
 		},
 		{
+			name: "primary-purpose-multiple-does-not-drop-packages",
+			doc: func() *sbom.Document {
+				doc := sbom.NewDocument()
+
+				first := sbom.NewNode()
+				first.Id = "first-node"
+				first.PrimaryPurpose = []sbom.Purpose{sbom.Purpose_LIBRARY}
+				doc.NodeList.Nodes = append(doc.NodeList.Nodes, first)
+
+				// A node with more than one PrimaryPurpose. SPDX keeps only the first.
+				multi := sbom.NewNode()
+				multi.Id = "multi-purpose-node"
+				multi.PrimaryPurpose = []sbom.Purpose{sbom.Purpose_LIBRARY, sbom.Purpose_APPLICATION}
+				doc.NodeList.Nodes = append(doc.NodeList.Nodes, multi)
+
+				last := sbom.NewNode()
+				last.Id = "last-node"
+				last.PrimaryPurpose = []sbom.Purpose{sbom.Purpose_APPLICATION}
+				doc.NodeList.Nodes = append(doc.NodeList.Nodes, last)
+
+				return doc
+			}(),
+			spdxopts: SPDX23Options{},
+			validate: func(t *testing.T, packages []*spdx.Package, err error) {
+				require.NoError(t, err)
+				// A node with multiple PrimaryPurpose values must not drop itself
+				// or any later package from the SBOM; all three must be present.
+				require.Len(t, packages, 3)
+				for _, pkg := range packages {
+					if string(pkg.PackageSPDXIdentifier) == "multi-purpose-node" {
+						require.Equal(t, "LIBRARY", pkg.PrimaryPackagePurpose)
+					}
+				}
+			},
+		},
+		{
 			name: "checksums-mapping",
 			doc: func() *sbom.Document {
 				doc := sbom.NewDocument()


### PR DESCRIPTION
`buildPackages` in the SPDX 2.3 serializer ranges over every node in the BOM, but the "multiple `PrimaryPurpose`" branch does a `break` from inside two `if` blocks:

```go
for _, node := range bom.NodeList.Nodes {
    ...
    if len(node.PrimaryPurpose) > 0 && (node.PrimaryPurpose[0] != sbom.Purpose_UNKNOWN_PURPOSE) {
        if len(node.PrimaryPurpose) > 1 {
            // ... using the first
            if true { // temp workaround in favor of adding a lint tag
                break
            }
        }
        switch node.PrimaryPurpose[0] { ... }
    }
    ...
    packages = append(packages, &p)
}
```

There is no loop or switch between that `break` and the `for _, node := range` loop, so it breaks the package range loop itself. The first package node that has more than one `PrimaryPurpose`, and every package after it in the node list, never reach the `packages = append(...)` below and are silently dropped, producing a truncated SPDX SBOM.

The `break` was added only to satisfy the SA9003 empty-branch linter (per #139); the intended behaviour, stated in the `TODO(degradation)` comment and already implemented by the `CycloneDX` serializer, is to use the first purpose — which the `switch node.PrimaryPurpose[0]` right below already does. This removes the loop-breaking block and falls through to that switch, so the empty branch (and the reason for the workaround) is gone.

Added a `TestBuildPackages` case with three package nodes where the middle one has two purposes: it fails before this change (only the first package is serialized) and passes after (all three present, the multi-purpose node keeps its first purpose).

Checked: `go test ./...`, `go build ./...`, `go vet ./pkg/native/serializers/...`, `gofmt -l`, `staticcheck ./pkg/native/serializers/` (no issues on the touched file).
