### PR TITLE
SPDX 2.2 + Tag-value support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ the golang library.
 
 | Format | Version | Encoding | Read | Write |
 | --- | --- | --- | --- | --- |
-| SPDX | 2.2 | JSON | planned | - |
-| SPDX | 2.2 | tag-value | planned | - |
-| SPDX | 2.3 | JSON | supported | supported|
-| SPDX | 2.3 | tag-value | planned | - |
+| SPDX | 2.2 | JSON | supported | supported |
+| SPDX | 2.2 | tag-value | supported | supported |
+| SPDX | 2.3 | JSON | supported | supported |
+| SPDX | 2.3 | tag-value | supported | supported |
 | SPDX | 3.0 | JSON | planned | planned |
+| SPDX | 3.1 | JSON | planned | planned |
 | CycloneDX | 1.4 | JSON | supported | supported |
 | CycloneDX | 1.5 | JSON | supported | supported |
 | CycloneDX | 1.6 | JSON | supported | supported |
+| CycloneDX | 1.7 | JSON | supported | supported |
 
 Other read and write implementations can potentially be written in
 other [languages supported by protobuf](https://protobuf.dev/getting-started/)

--- a/pkg/native/serializers/serializer_spdx22.go
+++ b/pkg/native/serializers/serializer_spdx22.go
@@ -1,0 +1,127 @@
+package serializers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spdx/tools-golang/convert"
+	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/spdx/v2/common"
+	v2_2 "github.com/spdx/tools-golang/spdx/v2/v2_2"
+
+	protospdx "github.com/protobom/protobom/pkg/formats/spdx"
+	"github.com/protobom/protobom/pkg/native"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+var _ native.Serializer = &SPDX22{}
+
+// SPDX22 serializes protobom documents to SPDX 2.2 in JSON encoding.
+// The document is built with the SPDX 2.3 serializer and downgraded
+// through the tools-golang conversion chain, degrading the data that
+// SPDX 2.2 cannot express (see downgradeDocument).
+type SPDX22 struct {
+	SPDX23
+}
+
+func NewSPDX22() *SPDX22 {
+	return &SPDX22{}
+}
+
+// Serialize converts a protobom document to an SPDX 2.2 document. It
+// accepts the same raw options as the SPDX 2.3 serializer.
+func (s *SPDX22) Serialize(bom *sbom.Document, opts *native.SerializeOptions, rawopts any) (any, error) {
+	doc, err := s.SPDX23.Serialize(bom, opts, rawopts)
+	if err != nil {
+		return nil, err
+	}
+	doc23, ok := doc.(*spdx.Document)
+	if !ok {
+		return nil, errors.New("unable to cast serialized document as SPDX 2.3")
+	}
+	doc22 := v2_2.Document{}
+	if err := convert.Document(doc23, &doc22); err != nil {
+		return nil, fmt.Errorf("downgrading document to SPDX 2.2: %w", err)
+	}
+	downgradeDocument(&doc22)
+	return &doc22, nil
+}
+
+// Render writes a serialized SPDX 2.2 document to the stream in JSON
+// encoding.
+func (s *SPDX22) Render(doc any, wr io.Writer, o *native.RenderOptions, _ any) error {
+	doc22, ok := doc.(*v2_2.Document)
+	if !ok {
+		return errors.New("unable to cast doc as SPDX 2.2 document")
+	}
+	encoder := json.NewEncoder(wr)
+	encoder.SetIndent("", strings.Repeat(" ", o.Indent))
+	if err := encoder.Encode(doc22); err != nil {
+		return fmt.Errorf("encoding sbom to stream: %w", err)
+	}
+	return nil
+}
+
+// spdx22ChecksumAlgorithms lists the checksum algorithms SPDX 2.2
+// defines. The algorithms 2.3 added (SHA3-*, BLAKE*, ADLER32) are
+// dropped when downgrading.
+var spdx22ChecksumAlgorithms = map[common.ChecksumAlgorithm]bool{
+	common.SHA224: true,
+	common.SHA1:   true,
+	common.SHA256: true,
+	common.SHA384: true,
+	common.SHA512: true,
+	common.MD2:    true,
+	common.MD4:    true,
+	common.MD5:    true,
+	common.MD6:    true,
+}
+
+// downgradeDocument degrades the data of a converted document that
+// SPDX 2.2 cannot express: checksum algorithms introduced in 2.3 are
+// dropped, and the licensing and copyright fields that 2.3 made
+// optional are backfilled with NOASSERTION as 2.2 requires them.
+// Fields 2.2 does not have (such as the primary package purpose) are
+// already dropped by the struct conversion.
+func downgradeDocument(doc *v2_2.Document) {
+	for _, p := range doc.Packages {
+		p.PackageChecksums = filterChecksums22(p.PackageChecksums)
+		if p.PackageDownloadLocation == "" {
+			p.PackageDownloadLocation = protospdx.NOASSERTION
+		}
+		if p.PackageLicenseConcluded == "" {
+			p.PackageLicenseConcluded = protospdx.NOASSERTION
+		}
+		if p.PackageLicenseDeclared == "" {
+			p.PackageLicenseDeclared = protospdx.NOASSERTION
+		}
+		if p.PackageCopyrightText == "" {
+			p.PackageCopyrightText = protospdx.NOASSERTION
+		}
+	}
+	for _, f := range doc.Files {
+		f.Checksums = filterChecksums22(f.Checksums)
+		if f.LicenseConcluded == "" {
+			f.LicenseConcluded = protospdx.NOASSERTION
+		}
+		if len(f.LicenseInfoInFiles) == 0 {
+			f.LicenseInfoInFiles = []string{protospdx.NOASSERTION}
+		}
+		if f.FileCopyrightText == "" {
+			f.FileCopyrightText = protospdx.NOASSERTION
+		}
+	}
+}
+
+func filterChecksums22(in []common.Checksum) []common.Checksum {
+	out := make([]common.Checksum, 0, len(in))
+	for _, c := range in {
+		if spdx22ChecksumAlgorithms[c.Algorithm] {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/pkg/native/serializers/serializer_spdx22_test.go
+++ b/pkg/native/serializers/serializer_spdx22_test.go
@@ -1,0 +1,134 @@
+package serializers
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spdx/tools-golang/spdx/v2/common"
+	v2_2 "github.com/spdx/tools-golang/spdx/v2/v2_2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/protobom/protobom/pkg/native"
+	"github.com/protobom/protobom/pkg/native/unserializers"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+func TestSPDX22Serialize(t *testing.T) {
+	s := NewSPDX22()
+	raw, err := s.Serialize(testTVDocument(t), &native.SerializeOptions{}, nil)
+	require.NoError(t, err)
+
+	doc22, ok := raw.(*v2_2.Document)
+	require.True(t, ok, "serialized document is not SPDX 2.2")
+	require.Equal(t, v2_2.Version, doc22.SPDXVersion)
+
+	require.Len(t, doc22.Packages, 1)
+	pkg := doc22.Packages[0]
+	require.Equal(t, "nginx", pkg.PackageName)
+	require.Equal(t, "Apache-2.0", pkg.PackageLicenseConcluded)
+	// Optional in 2.3, required in 2.2: backfilled on downgrade.
+	require.Equal(t, "NOASSERTION", pkg.PackageLicenseDeclared)
+	require.NotEmpty(t, pkg.PackageCopyrightText)
+
+	require.Len(t, doc22.Files, 1)
+	file := doc22.Files[0]
+	require.Equal(t, "etc/nginx/nginx.conf", file.FileName)
+	require.Equal(t, "NOASSERTION", file.LicenseConcluded)
+	require.Equal(t, []string{"NOASSERTION"}, file.LicenseInfoInFiles)
+	require.NotEmpty(t, file.FileCopyrightText)
+}
+
+func TestSPDX22RenderJSON(t *testing.T) {
+	s := NewSPDX22()
+	raw, err := s.Serialize(testTVDocument(t), &native.SerializeOptions{}, nil)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(raw, &buf, &native.RenderOptions{Indent: 2}, nil))
+	require.Contains(t, buf.String(), `"spdxVersion": "SPDX-2.2"`)
+	require.Contains(t, buf.String(), `"name": "nginx"`)
+}
+
+func TestSPDX22TVRender(t *testing.T) {
+	s := NewSPDX22TV()
+	raw, err := s.Serialize(testTVDocument(t), &native.SerializeOptions{}, nil)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(raw, &buf, &native.RenderOptions{}, nil))
+	for _, expected := range []string{
+		"SPDXVersion: SPDX-2.2",
+		"PackageName: nginx",
+		"PackageVersion: 1.25.3",
+		"FileName: etc/nginx/nginx.conf",
+	} {
+		require.Contains(t, buf.String(), expected+"\n")
+	}
+}
+
+// TestSPDX22TVRoundTrip writes a document as SPDX 2.2 tag-value and
+// reads it back through the 2.2 unserializer.
+func TestSPDX22TVRoundTrip(t *testing.T) {
+	s := NewSPDX22TV()
+	raw, err := s.Serialize(testTVDocument(t), &native.SerializeOptions{}, nil)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(raw, &buf, &native.RenderOptions{}, nil))
+
+	doc, err := unserializers.NewSPDX22TV().Unserialize(
+		strings.NewReader(buf.String()), &native.UnserializeOptions{}, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, doc.GetNodeList().GetNodes(), 2)
+
+	var pkgNode *sbom.Node
+	for _, n := range doc.GetNodeList().GetNodes() {
+		if n.GetType() == sbom.Node_PACKAGE {
+			pkgNode = n
+		}
+	}
+	require.NotNil(t, pkgNode)
+	require.Equal(t, "nginx", pkgNode.GetName())
+	require.Equal(t, "1.25.3", pkgNode.GetVersion())
+}
+
+func TestDowngradeDocument(t *testing.T) {
+	doc := &v2_2.Document{
+		Packages: []*v2_2.Package{{
+			PackageName: "test",
+			PackageChecksums: []common.Checksum{
+				{Algorithm: common.SHA256, Value: "aa"},
+				{Algorithm: common.BLAKE3, Value: "bb"},
+				{Algorithm: common.SHA3_256, Value: "cc"},
+			},
+		}},
+		Files: []*v2_2.File{{
+			FileName: "test.txt",
+			Checksums: []common.Checksum{
+				{Algorithm: common.SHA1, Value: "dd"},
+				{Algorithm: common.ADLER32, Value: "ee"},
+			},
+		}},
+	}
+	downgradeDocument(doc)
+
+	// Algorithms 2.3 introduced are dropped, 2.2 ones are kept.
+	require.Equal(t,
+		[]common.Checksum{{Algorithm: common.SHA256, Value: "aa"}},
+		doc.Packages[0].PackageChecksums,
+	)
+	require.Equal(t,
+		[]common.Checksum{{Algorithm: common.SHA1, Value: "dd"}},
+		doc.Files[0].Checksums,
+	)
+
+	// Fields required in 2.2 are backfilled.
+	require.Equal(t, "NOASSERTION", doc.Packages[0].PackageDownloadLocation)
+	require.Equal(t, "NOASSERTION", doc.Packages[0].PackageLicenseConcluded)
+	require.Equal(t, "NOASSERTION", doc.Packages[0].PackageLicenseDeclared)
+	require.Equal(t, "NOASSERTION", doc.Packages[0].PackageCopyrightText)
+	require.Equal(t, "NOASSERTION", doc.Files[0].LicenseConcluded)
+	require.Equal(t, []string{"NOASSERTION"}, doc.Files[0].LicenseInfoInFiles)
+	require.Equal(t, "NOASSERTION", doc.Files[0].FileCopyrightText)
+}

--- a/pkg/native/serializers/serializer_spdx22tv.go
+++ b/pkg/native/serializers/serializer_spdx22tv.go
@@ -1,0 +1,38 @@
+package serializers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	v2_2 "github.com/spdx/tools-golang/spdx/v2/v2_2"
+	"github.com/spdx/tools-golang/tagvalue"
+
+	"github.com/protobom/protobom/pkg/native"
+)
+
+var _ native.Serializer = &SPDX22TV{}
+
+// SPDX22TV serializes protobom documents to SPDX 2.2 in tag-value
+// encoding. The conversion to the SPDX 2.2 model is shared with the
+// JSON serializer, only the rendering differs.
+type SPDX22TV struct {
+	SPDX22
+}
+
+func NewSPDX22TV() *SPDX22TV {
+	return &SPDX22TV{}
+}
+
+// Render writes a serialized SPDX 2.2 document to the stream in
+// tag-value encoding.
+func (s *SPDX22TV) Render(doc any, wr io.Writer, _ *native.RenderOptions, _ any) error {
+	doc22, ok := doc.(*v2_2.Document)
+	if !ok {
+		return errors.New("unable to cast doc as SPDX 2.2 document")
+	}
+	if err := tagvalue.Write(doc22, wr); err != nil {
+		return fmt.Errorf("writing SPDX tag-value: %w", err)
+	}
+	return nil
+}

--- a/pkg/native/serializers/serializer_spdx23tv.go
+++ b/pkg/native/serializers/serializer_spdx23tv.go
@@ -1,0 +1,38 @@
+package serializers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/tagvalue"
+
+	"github.com/protobom/protobom/pkg/native"
+)
+
+var _ native.Serializer = &SPDX23TV{}
+
+// SPDX23TV serializes protobom documents to SPDX 2.3 in tag-value
+// encoding. The conversion to the SPDX model is shared with the JSON
+// serializer; only the rendering differs.
+type SPDX23TV struct {
+	SPDX23
+}
+
+func NewSPDX23TV() *SPDX23TV {
+	return &SPDX23TV{}
+}
+
+// Render writes a serialized SPDX 2.3 document to the stream in
+// tag-value encoding.
+func (s *SPDX23TV) Render(doc any, wr io.Writer, _ *native.RenderOptions, _ any) error {
+	spdxDoc, ok := doc.(*spdx.Document)
+	if !ok {
+		return errors.New("unable to cast doc as spdx.Document")
+	}
+	if err := tagvalue.Write(spdxDoc, wr); err != nil {
+		return fmt.Errorf("writing SPDX tag-value: %w", err)
+	}
+	return nil
+}

--- a/pkg/native/serializers/serializer_spdx23tv_test.go
+++ b/pkg/native/serializers/serializer_spdx23tv_test.go
@@ -1,0 +1,73 @@
+package serializers
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/protobom/protobom/pkg/native"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+// testTVDocument builds a protobom document with a package containing
+// a file.
+func testTVDocument(t *testing.T) *sbom.Document {
+	t.Helper()
+	doc := sbom.NewDocument()
+	doc.Metadata.Id = "https://example.com/test/spdx23tv#SPDXRef-DOCUMENT"
+	doc.Metadata.Name = "spdx23tv-test"
+	doc.Metadata.Date = timestamppb.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	pkg := &sbom.Node{
+		Id:               "Package-nginx",
+		Type:             sbom.Node_PACKAGE,
+		Name:             "nginx",
+		Version:          "1.25.3",
+		LicenseConcluded: "Apache-2.0",
+		Identifiers: map[int32]string{
+			int32(sbom.SoftwareIdentifierType_PURL): "pkg:oci/nginx@1.25.3",
+		},
+		Hashes: map[int32]string{
+			int32(sbom.HashAlgorithm_SHA256): "9f7fd60e5346e9b6b9e6dbc769ffca94a394a5253bb45a2cbca4fbe3f4d34a0f",
+		},
+	}
+	doc.GetNodeList().AddRootNode(pkg)
+
+	file := &sbom.Node{
+		Id:   "File-nginx-conf",
+		Type: sbom.Node_FILE,
+		Name: "etc/nginx/nginx.conf",
+		Hashes: map[int32]string{
+			int32(sbom.HashAlgorithm_SHA256): "b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1",
+		},
+	}
+	require.NoError(t, doc.GetNodeList().RelateNodeAtID(file, "Package-nginx", sbom.Edge_contains))
+	return doc
+}
+
+func TestSPDX23TVRender(t *testing.T) {
+	s := NewSPDX23TV()
+	raw, err := s.Serialize(testTVDocument(t), &native.SerializeOptions{}, nil)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(raw, &buf, &native.RenderOptions{}, nil))
+
+	for _, expected := range []string{
+		"SPDXVersion: SPDX-2.3",
+		"DocumentNamespace: https://example.com/test/spdx23tv",
+		"PackageName: nginx",
+		"PackageVersion: 1.25.3",
+		"ExternalRef: PACKAGE-MANAGER purl pkg:oci/nginx@1.25.3",
+		"FileName: etc/nginx/nginx.conf",
+	} {
+		require.Contains(t, buf.String(), expected+"\n")
+	}
+}
+
+func TestSPDX23TVRenderInvalidType(t *testing.T) {
+	require.Error(t, NewSPDX23TV().Render(struct{}{}, &bytes.Buffer{}, &native.RenderOptions{}, nil))
+}

--- a/pkg/native/unserializers/unserializer_spdx22.go
+++ b/pkg/native/unserializers/unserializer_spdx22.go
@@ -1,0 +1,19 @@
+package unserializers
+
+import (
+	"github.com/protobom/protobom/pkg/native"
+)
+
+var _ native.Unserializer = &SPDX22{}
+
+// SPDX22 parses SPDX 2.2 documents in JSON encoding. The tools-golang
+// parser reads all SPDX 2.x versions and upgrades them to the 2.3
+// model, so the document conversion is fully shared with the SPDX 2.3
+// unserializer.
+type SPDX22 struct {
+	SPDX23
+}
+
+func NewSPDX22() *SPDX22 {
+	return &SPDX22{}
+}

--- a/pkg/native/unserializers/unserializer_spdx22_test.go
+++ b/pkg/native/unserializers/unserializer_spdx22_test.go
@@ -1,0 +1,78 @@
+package unserializers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/protobom/protobom/pkg/native"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+const testJSON22Document = `{
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "json22-test-doc",
+  "documentNamespace": "https://example.com/test/json22",
+  "creationInfo": {
+    "created": "2026-01-01T00:00:00Z",
+    "creators": ["Organization: protobom"]
+  },
+  "packages": [
+    {
+      "name": "kubectl",
+      "SPDXID": "SPDXRef-Package-kubectl",
+      "versionInfo": "v1.33.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    }
+  ],
+  "documentDescribes": ["SPDXRef-Package-kubectl"]
+}`
+
+func TestSPDX22Unserialize(t *testing.T) {
+	doc, err := NewSPDX22().Unserialize(
+		strings.NewReader(testJSON22Document), &native.UnserializeOptions{}, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "json22-test-doc", doc.GetMetadata().GetName())
+	require.Len(t, doc.GetNodeList().GetNodes(), 1)
+
+	node := doc.GetNodeList().GetNodes()[0]
+	require.Equal(t, "kubectl", node.GetName())
+	require.Equal(t, "v1.33.0", node.GetVersion())
+	require.Equal(t, "Apache-2.0", node.GetLicenseConcluded())
+	require.Contains(t, doc.GetNodeList().GetRootElements(), node.GetId())
+}
+
+func TestSPDX22TVUnserialize(t *testing.T) {
+	// The 2.3 test document with the version replaced parses through
+	// the same shared conversion.
+	tv := strings.Replace(testTagValueDocument, "SPDXVersion: SPDX-2.3", "SPDXVersion: SPDX-2.2", 1)
+
+	doc, err := NewSPDX22TV().Unserialize(
+		strings.NewReader(tv), &native.UnserializeOptions{}, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "tv-test-doc", doc.GetMetadata().GetName())
+	require.Len(t, doc.GetNodeList().GetNodes(), 2)
+
+	var pkgNode, fileNode *sbom.Node
+	for _, n := range doc.GetNodeList().GetNodes() {
+		switch n.GetType() {
+		case sbom.Node_PACKAGE:
+			pkgNode = n
+		case sbom.Node_FILE:
+			fileNode = n
+		}
+	}
+	require.NotNil(t, pkgNode, "package node not found")
+	require.NotNil(t, fileNode, "file node not found (package files not hoisted)")
+	require.Equal(t, "kubectl", pkgNode.GetName())
+	require.Equal(t, "bin/kubectl", fileNode.GetName())
+}

--- a/pkg/native/unserializers/unserializer_spdx22tv.go
+++ b/pkg/native/unserializers/unserializer_spdx22tv.go
@@ -1,0 +1,19 @@
+package unserializers
+
+import (
+	"github.com/protobom/protobom/pkg/native"
+)
+
+var _ native.Unserializer = &SPDX22TV{}
+
+// SPDX22TV parses SPDX 2.2 documents in tag-value encoding. The
+// tools-golang parser reads all SPDX 2.x versions and upgrades them to
+// the 2.3 model, so the decoding and document conversion are fully
+// shared with the SPDX 2.3 tag-value unserializer.
+type SPDX22TV struct {
+	SPDX23TV
+}
+
+func NewSPDX22TV() *SPDX22TV {
+	return &SPDX22TV{}
+}

--- a/pkg/native/unserializers/unserializer_spdx23.go
+++ b/pkg/native/unserializers/unserializer_spdx23.go
@@ -57,6 +57,13 @@ func (u *SPDX23) Unserialize(r io.Reader, opts *native.UnserializeOptions, _ int
 		return nil, fmt.Errorf("parsing SPDX json: %w", err)
 	}
 
+	return u.unserializeDocument(spdxDoc, opts)
+}
+
+// unserializeDocument converts an SPDX 2.3 document parsed by
+// spdx/tools-golang into its protobom representation. It is shared by
+// the encoding-specific unserializers (JSON and tag-value).
+func (u *SPDX23) unserializeDocument(spdxDoc *spdx23.Document, opts *native.UnserializeOptions) (*sbom.Document, error) {
 	bom := sbom.NewDocument()
 	bom.Metadata.Id = buildDocumentIdentifier(spdxDoc)
 	bom.Metadata.Name = spdxDoc.DocumentName

--- a/pkg/native/unserializers/unserializer_spdx23tv.go
+++ b/pkg/native/unserializers/unserializer_spdx23tv.go
@@ -1,0 +1,75 @@
+package unserializers
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spdx/tools-golang/spdx/v2/common"
+	spdx23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
+	"github.com/spdx/tools-golang/tagvalue"
+
+	"github.com/protobom/protobom/pkg/native"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+var _ native.Unserializer = &SPDX23TV{}
+
+// SPDX23TV parses SPDX 2.3 documents in tag-value encoding. The
+// conversion of the parsed document is shared with the JSON
+// unserializer, only the decoding differs.
+type SPDX23TV struct {
+	SPDX23
+}
+
+func NewSPDX23TV() *SPDX23TV {
+	return &SPDX23TV{}
+}
+
+// Unserialize reads an SPDX 2.3 tag-value document from the stream and
+// returns its protobom representation.
+func (u *SPDX23TV) Unserialize(r io.Reader, opts *native.UnserializeOptions, _ interface{}) (*sbom.Document, error) {
+	spdxDoc, err := tagvalue.Read(r)
+	if err != nil {
+		return nil, fmt.Errorf("parsing SPDX tag-value: %w", err)
+	}
+	hoistPackageFiles(spdxDoc)
+	return u.unserializeDocument(spdxDoc, opts)
+}
+
+// hoistPackageFiles moves files nested in packages to the document
+// level, keeping a CONTAINS relationship in their place. The tag-value
+// parser attaches the file sections that follow a package to that
+// package, but the shared document conversion reads files from the
+// document level only (as json has no nested files) so without
+// hoisting them to the doc level, the package files would be lost.
+func hoistPackageFiles(doc *spdx23.Document) {
+	seen := map[common.ElementID]bool{}
+	for _, f := range doc.Files {
+		seen[f.FileSPDXIdentifier] = true
+	}
+	related := map[common.ElementID]map[common.ElementID]bool{}
+	for _, rel := range doc.Relationships {
+		if rel.Relationship == common.TypeRelationshipContains {
+			if related[rel.RefA.ElementRefID] == nil {
+				related[rel.RefA.ElementRefID] = map[common.ElementID]bool{}
+			}
+			related[rel.RefA.ElementRefID][rel.RefB.ElementRefID] = true
+		}
+	}
+	for _, p := range doc.Packages {
+		for _, f := range p.Files {
+			if !seen[f.FileSPDXIdentifier] {
+				doc.Files = append(doc.Files, f)
+				seen[f.FileSPDXIdentifier] = true
+			}
+			if !related[p.PackageSPDXIdentifier][f.FileSPDXIdentifier] {
+				doc.Relationships = append(doc.Relationships, &spdx23.Relationship{
+					RefA:         common.DocElementID{ElementRefID: p.PackageSPDXIdentifier},
+					RefB:         common.DocElementID{ElementRefID: f.FileSPDXIdentifier},
+					Relationship: common.TypeRelationshipContains,
+				})
+			}
+		}
+		p.Files = nil
+	}
+}

--- a/pkg/native/unserializers/unserializer_spdx23tv_test.go
+++ b/pkg/native/unserializers/unserializer_spdx23tv_test.go
@@ -1,0 +1,96 @@
+package unserializers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/protobom/protobom/pkg/native"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+// testTagValueDocument places the file section after the package
+// section. The tag-value parser attaches such files to the preceding
+// package, which exercises the hoisting to the document level.
+const testTagValueDocument = `SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: tv-test-doc
+DocumentNamespace: https://example.com/test/tv
+Creator: Organization: protobom
+Created: 2026-01-01T00:00:00Z
+
+PackageName: kubectl
+SPDXID: SPDXRef-Package-kubectl
+PackageVersion: v1.33.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+
+FileName: bin/kubectl
+SPDXID: SPDXRef-File-kubectl
+FileChecksum: SHA256: e5f7a7ed445673057c73686cb846e0c33ff0d5701fd43bf6aff16bb39ae14de2
+LicenseConcluded: Apache-2.0
+FileCopyrightText: NOASSERTION
+
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-kubectl
+`
+
+func TestSPDX23TVUnserialize(t *testing.T) {
+	doc, err := NewSPDX23TV().Unserialize(
+		strings.NewReader(testTagValueDocument), &native.UnserializeOptions{}, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "tv-test-doc", doc.GetMetadata().GetName())
+	// tools-golang strips the SPDXRef- prefix from element identifiers,
+	// so the document fragment reads DOCUMENT, as in the JSON path.
+	require.Equal(t, "https://example.com/test/tv#DOCUMENT", doc.GetMetadata().GetId())
+
+	require.Len(t, doc.GetNodeList().GetNodes(), 2)
+	var pkgNode, fileNode *sbom.Node
+	for _, n := range doc.GetNodeList().GetNodes() {
+		switch n.GetType() {
+		case sbom.Node_PACKAGE:
+			pkgNode = n
+		case sbom.Node_FILE:
+			fileNode = n
+		}
+	}
+	require.NotNil(t, pkgNode, "package node not found")
+	require.NotNil(t, fileNode, "file node not found (package files not hoisted)")
+	require.Equal(t, "kubectl", pkgNode.GetName())
+	require.Equal(t, "v1.33.0", pkgNode.GetVersion())
+	require.Equal(t, "Apache-2.0", pkgNode.GetLicenseConcluded())
+	require.Equal(t, "bin/kubectl", fileNode.GetName())
+	require.Equal(t,
+		"e5f7a7ed445673057c73686cb846e0c33ff0d5701fd43bf6aff16bb39ae14de2",
+		fileNode.GetHashes()[int32(sbom.HashAlgorithm_SHA256)],
+	)
+
+	// The document DESCRIBES relationship becomes the root element.
+	require.Contains(t, doc.GetNodeList().GetRootElements(), pkgNode.GetId())
+
+	// The hoisted file must be related to its package with an edge.
+	related := false
+	for _, edge := range doc.GetNodeList().GetEdges() {
+		if edge.GetFrom() == pkgNode.GetId() {
+			for _, to := range edge.GetTo() {
+				if to == fileNode.GetId() {
+					require.Equal(t, sbom.Edge_contains, edge.GetType())
+					related = true
+				}
+			}
+		}
+	}
+	require.True(t, related, "package -> file edge not found")
+}
+
+func TestSPDX23TVUnserializeInvalid(t *testing.T) {
+	_, err := NewSPDX23TV().Unserialize(
+		strings.NewReader("not a tag value document"), &native.UnserializeOptions{}, nil,
+	)
+	require.Error(t, err)
+}

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -53,6 +53,8 @@ func init() {
 	unserializers[formats.SPDX23JSON] = drivers.NewSPDX23()
 	unserializers[formats.SPDX3JSON] = drivers.NewSPDX3()
 	unserializers[formats.SPDX23TV] = drivers.NewSPDX23TV()
+	unserializers[formats.SPDX22JSON] = drivers.NewSPDX22()
+	unserializers[formats.SPDX22TV] = drivers.NewSPDX22TV()
 	regMtx.Unlock()
 }
 

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -52,6 +52,7 @@ func init() {
 	unserializers[formats.CDX17JSON] = drivers.NewCDX("1.7", formats.JSON)
 	unserializers[formats.SPDX23JSON] = drivers.NewSPDX23()
 	unserializers[formats.SPDX3JSON] = drivers.NewSPDX3()
+	unserializers[formats.SPDX23TV] = drivers.NewSPDX23TV()
 	regMtx.Unlock()
 }
 

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -58,6 +58,7 @@ func ensureSerializersInitialized() {
 		serializers.Store(formats.CDX17JSON, drivers.NewCDX("1.7", formats.JSON))
 		serializers.Store(formats.SPDX23JSON, drivers.NewSPDX23())
 		serializers.Store(formats.SPDX3JSON, drivers.NewSPDX3())
+		serializers.Store(formats.SPDX23TV, drivers.NewSPDX23TV())
 	})
 }
 

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -59,6 +59,8 @@ func ensureSerializersInitialized() {
 		serializers.Store(formats.SPDX23JSON, drivers.NewSPDX23())
 		serializers.Store(formats.SPDX3JSON, drivers.NewSPDX3())
 		serializers.Store(formats.SPDX23TV, drivers.NewSPDX23TV())
+		serializers.Store(formats.SPDX22JSON, drivers.NewSPDX22())
+		serializers.Store(formats.SPDX22TV, drivers.NewSPDX22TV())
 	})
 }
 


### PR DESCRIPTION
This PR adds full support for SPDX 2.2 and in addition adds tag-value support to 2.2 and 2.3 completing the first batch of planned serializers and unserializers.

/cc @cpanato 