### PR TITLE
fix(cyclonedx): serialize license expressions as expressions, not license IDs

### DIFF
--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -452,11 +452,7 @@ func (s *CDX) nodeToComponent(n *sbom.Node) *cdx.Component {
 		var licenseChoices []cdx.LicenseChoice
 		var licenses cdx.Licenses
 		for _, l := range n.Licenses {
-			licenseChoices = append(licenseChoices, cdx.LicenseChoice{
-				License: &cdx.License{
-					ID: l,
-				},
-			})
+			licenseChoices = append(licenseChoices, protobomLicenseToCdx(l))
 		}
 
 		licenses = licenseChoices
@@ -671,6 +667,31 @@ func (s *CDX) protobomExtRefTypeToCdxType(protoExtRefType sbom.ExternalReference
 	default:
 		return cdx.ERTypeOther
 	}
+}
+
+// protobomLicenseToCdx renders a single protobom license string as a CycloneDX
+// license choice. A compound SPDX expression is emitted through the Expression
+// field; a bare license keeps using License.ID. CycloneDX only accepts a single
+// SPDX identifier in License.ID, so placing an expression there (e.g.
+// "Apache-2.0 OR MIT") produces an invalid document and defeats the round-trip:
+// the unserializer already reads an expression back into the same license slice
+// (see licenseChoicesToLicenseList).
+func protobomLicenseToCdx(license string) cdx.LicenseChoice {
+	if isSPDXLicenseExpression(license) {
+		return cdx.LicenseChoice{Expression: license}
+	}
+	return cdx.LicenseChoice{License: &cdx.License{ID: license}}
+}
+
+// isSPDXLicenseExpression reports whether a license string is a compound SPDX
+// expression rather than a single identifier. SPDX identifiers never contain
+// spaces, so the AND/OR/WITH operators and grouping parentheses only ever
+// appear in expressions.
+func isSPDXLicenseExpression(license string) bool {
+	return strings.Contains(license, " AND ") ||
+		strings.Contains(license, " OR ") ||
+		strings.Contains(license, " WITH ") ||
+		strings.ContainsAny(license, "()")
 }
 
 // protoHashAlgoToCdxAlgo converts the protobom algorithm to the CDX

--- a/pkg/native/serializers/serializer_cdx_test.go
+++ b/pkg/native/serializers/serializer_cdx_test.go
@@ -80,6 +80,47 @@ func TestComponentType(t *testing.T) {
 	}
 }
 
+func TestNodeLicensesToComponent(t *testing.T) {
+	sut := CDX{}
+	for name, tc := range map[string]struct {
+		licenses []string
+		expected cdx.Licenses
+	}{
+		"single identifier": {
+			licenses: []string{"Apache-2.0"},
+			expected: cdx.Licenses{{License: &cdx.License{ID: "Apache-2.0"}}},
+		},
+		"or expression": {
+			licenses: []string{"Apache-2.0 OR MIT"},
+			expected: cdx.Licenses{{Expression: "Apache-2.0 OR MIT"}},
+		},
+		"and expression": {
+			licenses: []string{"MIT AND BSD-3-Clause"},
+			expected: cdx.Licenses{{Expression: "MIT AND BSD-3-Clause"}},
+		},
+		"with exception": {
+			licenses: []string{"GPL-2.0-or-later WITH Classpath-exception-2.0"},
+			expected: cdx.Licenses{{Expression: "GPL-2.0-or-later WITH Classpath-exception-2.0"}},
+		},
+		"grouped expression": {
+			licenses: []string{"(MIT OR Apache-2.0) AND BSD-3-Clause"},
+			expected: cdx.Licenses{{Expression: "(MIT OR Apache-2.0) AND BSD-3-Clause"}},
+		},
+		"identifier and expression": {
+			licenses: []string{"MIT", "Apache-2.0 OR MIT"},
+			expected: cdx.Licenses{
+				{License: &cdx.License{ID: "MIT"}},
+				{Expression: "Apache-2.0 OR MIT"},
+			},
+		},
+	} {
+		node := &sbom.Node{Licenses: tc.licenses}
+		comp := sut.nodeToComponent(node)
+		require.NotNil(t, comp.Licenses, name)
+		require.Equal(t, tc.expected, *comp.Licenses, name)
+	}
+}
+
 func TestEdgeTypeToScope(t *testing.T) {
 	for edgeType, expected := range map[sbom.Edge_Type]cdx.Scope{
 		sbom.Edge_runtimeDependency: cdx.ScopeRequired,


### PR DESCRIPTION
`nodeToComponent` in the CycloneDX serializer turns every entry of `node.Licenses` into a `cdx.LicenseChoice` with `License.ID` set:

```go
for _, l := range n.Licenses {
    licenseChoices = append(licenseChoices, cdx.LicenseChoice{
        License: &cdx.License{
            ID: l,
        },
    })
}
```

But `node.Licenses` can hold SPDX expressions, not just single identifiers. The unserializer puts them there: `licenseChoicesToLicenseList` appends `lc.Expression` (e.g. `Apache-2.0 OR MIT`) into the same slice it fills with `lc.License.ID`. In CycloneDX, `license.id` must be a single SPDX license identifier — a compound expression belongs in `license.expression`. Emitting the expression as an `id` produces an invalid document, and a reader treats `Apache-2.0 OR MIT` as one opaque license id instead of an OR of two.

This breaks the round-trip. Reading a CycloneDX BOM with a license expression and writing it back:

```
input:  "licenses": [{ "expression": "Apache-2.0 OR MIT" }]
before: "licenses": [{ "license": { "id": "Apache-2.0 OR MIT" } }]
after:  "licenses": [{ "expression": "Apache-2.0 OR MIT" }]
```

The fix routes each license through `Expression` when the string is a compound SPDX expression (it contains an `AND`/`OR`/`WITH` operator or grouping parentheses) and keeps `License.ID` for a bare identifier. SPDX identifiers never contain spaces, so those operators only show up in expressions. protobom already detects expressions with the same `" OR "`/parenthesis check in `spdx3_licenses.go`.

Added `TestNodeLicensesToComponent` covering a single id, `OR`/`AND`/`WITH` and grouped expressions, and a mixed slice: the expression cases fail before this change (they come out as `license.id`) and pass after.

Checked: `go test ./...`, `go build ./...`, `go vet ./pkg/native/serializers/...`, `gofmt -l` (clean on the touched files).
