### PR TITLE
Fix GetNodesByPurlType marking dependencies as root elements

### DIFF
--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -818,19 +818,27 @@ func (nl *NodeList) GetNodesByPurlType(purlType string) *NodeList {
 // reconnectOrphanNodes cleans the nodelist graph structure by reconnecting all
 // orphaned nodes to the top of the nodelist
 func (nl *NodeList) reconnectOrphanNodes() {
-	edgeIndex := nl.indexEdges()
 	rootIndex := nl.indexRootElements()
 
-	for _, id := range nl.RootElements {
-		rootIndex[id] = struct{}{}
+	// A node is orphaned only when nothing points to it, so index the nodes
+	// that are the destination of an edge. Keying on the edge source instead
+	// would treat a leaf dependency (a node with an incoming edge but no
+	// outgoing one) as an orphan and promote it to a root.
+	connected := map[string]struct{}{}
+	for _, e := range nl.Edges {
+		for _, toID := range e.To {
+			connected[toID] = struct{}{}
+		}
 	}
 
 	for _, n := range nl.Nodes {
-		if _, ok := edgeIndex[n.Id]; !ok {
-			if _, ok := rootIndex[n.Id]; !ok {
-				nl.RootElements = append(nl.RootElements, n.Id)
-			}
+		if _, ok := connected[n.Id]; ok {
+			continue
 		}
+		if _, ok := rootIndex[n.Id]; ok {
+			continue
+		}
+		nl.RootElements = append(nl.RootElements, n.Id)
 	}
 }
 

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -1532,3 +1532,62 @@ func TestRelateNodeListAtId(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNodesByPurlTypeRoots(t *testing.T) {
+	golangNode := func(id string) *Node {
+		return &Node{
+			Id:   id,
+			Type: Node_PACKAGE,
+			Identifiers: map[int32]string{
+				int32(SoftwareIdentifierType_PURL): "pkg:golang/example.com/" + id,
+			},
+		}
+	}
+	npmNode := func(id string) *Node {
+		return &Node{
+			Id:   id,
+			Type: Node_PACKAGE,
+			Identifiers: map[int32]string{
+				int32(SoftwareIdentifierType_PURL): "pkg:npm/" + id,
+			},
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		sut           *NodeList
+		expectedRoots []string
+	}{
+		// A dependency of the retained root has an incoming edge, so it must
+		// stay a dependency and not be promoted alongside (or instead of) the
+		// real root.
+		"dependency is not promoted to root": {
+			sut: &NodeList{
+				Nodes: []*Node{golangNode("app"), golangNode("lib")},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "app", To: []string{"lib"}},
+				},
+				RootElements: []string{"app"},
+			},
+			expectedRoots: []string{"app"},
+		},
+		// The parent of a retained subtree is a different purl type and is
+		// filtered out, so the subtree root loses its incoming edge and must be
+		// reconnected to the top even though it still has an outgoing edge.
+		"node whose parent was filtered out is reconnected": {
+			sut: &NodeList{
+				Nodes: []*Node{npmNode("app"), golangNode("lib"), golangNode("sublib")},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "app", To: []string{"lib"}},
+					{Type: Edge_dependsOn, From: "lib", To: []string{"sublib"}},
+				},
+				RootElements: []string{"app"},
+			},
+			expectedRoots: []string{"lib"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := tc.sut.GetNodesByPurlType("golang")
+			require.Equal(t, tc.expectedRoots, got.RootElements)
+		})
+	}
+}


### PR DESCRIPTION
`reconnectOrphanNodes`, called at the end of `GetNodesByPurlType`, reattaches nodes that lost their parent during filtering back to the top of the list. It decides a node is orphaned by checking whether the node is the source of an edge:

```go
edgeIndex := nl.indexEdges()
...
for _, n := range nl.Nodes {
    if _, ok := edgeIndex[n.Id]; !ok {
        if _, ok := rootIndex[n.Id]; !ok {
            nl.RootElements = append(nl.RootElements, n.Id)
        }
    }
}
```

`indexEdges()` keys edges by `From`, so `edgeIndex[n.Id]` is set only when `n` has an outgoing edge. A leaf dependency — a node something depends on but that has no dependencies of its own — has no outgoing edge, so it is treated as an orphan and promoted to a root, while the actual root (which does have an outgoing edge) is never added.

For an `app -> lib` graph (both `pkg:golang`) filtered with `GetNodesByPurlType("golang")`, `RootElements` comes back as `["lib"]` instead of `["app"]`: the dependency becomes the root and the real root is dropped. The same check also misses the case it was written for — a subtree whose parent was filtered out keeps its outgoing edge, so it is not reconnected.

A node is orphaned only when nothing points to it, so this indexes the edge destinations (`To`) instead and promotes the nodes with no incoming edge.

`TestGetNodesByPurlTypeRoots` covers both a dependency that must stay a dependency and a subtree whose parent was filtered out. Both cases fail before the change and pass after; `go test ./...` is green.
