### PR TITLE
Preserve SPDX 2.3 file license info

### DIFF
--- a/pkg/native/serializers/serializer_spdx23.go
+++ b/pkg/native/serializers/serializer_spdx23.go
@@ -276,10 +276,10 @@ func buildFiles(bom *sbom.Document) ([]*spdx.File, error) { //nolint:unparam
 			FileTypes:          node.FileTypes,
 			Checksums:          []common.Checksum{},
 			LicenseConcluded:   node.LicenseConcluded,
-			// LicenseInfoInFiles:   []string{}, << bug in SPDX
-			LicenseComments:   node.LicenseComments,
-			FileCopyrightText: strings.TrimSpace(node.Copyright),
-			FileComment:       node.Comment,
+			LicenseInfoInFiles: append([]string{}, node.Licenses...),
+			LicenseComments:    node.LicenseComments,
+			FileCopyrightText:  strings.TrimSpace(node.Copyright),
+			FileComment:        node.Comment,
 			// FileNotice:           node.File, // Missing?
 			FileAttributionTexts: node.Attribution,
 			Annotations:          []v2_3.Annotation{},

--- a/pkg/native/serializers/serializer_spdx23_test.go
+++ b/pkg/native/serializers/serializer_spdx23_test.go
@@ -242,6 +242,23 @@ func TestPropertiesMod(t *testing.T) {
 	}
 }
 
+func TestBuildFilesPreservesLicenseInfo(t *testing.T) {
+	doc := sbom.NewDocument()
+	n := sbom.NewNode()
+	n.Id = "file-with-license"
+	n.Type = sbom.Node_FILE
+	n.Name = "./main.go"
+	n.Licenses = []string{"MIT"}
+	n.LicenseConcluded = "MIT"
+	doc.NodeList.Nodes = append(doc.NodeList.Nodes, n)
+
+	files, err := buildFiles(doc)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "MIT", files[0].LicenseConcluded)
+	require.Equal(t, []string{"MIT"}, files[0].LicenseInfoInFiles)
+}
+
 func TestBuildPackages(t *testing.T) {
 	s23 := NewSPDX23()
 


### PR DESCRIPTION
SPDX 2.3 files have a `licenseInfoInFiles` field, and the SPDX 2.3 unserializer already maps that field into `Node.Licenses`. The serializer was not writing file node licenses back out, so a file-level license stored in protobom was dropped when writing SPDX 2.3.

This copies file node `Licenses` into `LicenseInfoInFiles` while leaving `LicenseConcluded` unchanged. The regression test covers a file node with `Licenses: []string{"MIT"}` and verifies the SPDX file keeps both the concluded license and the license info in file.

Tests:

- `go test ./pkg/native/serializers -run TestBuildFilesPreservesLicenseInfo -count=1` (failed before the fix with `actual: []string(nil)`)
- `go test ./pkg/native/serializers -count=1`
- `go test ./test/conformance/... -count=1`
- `go test ./... -count=1`
- `go get -d ./...`
- `go test -v ./... -count=1`
- `go test -race ./pkg/native/serializers -run TestBuildFilesPreservesLicenseInfo -count=10`
- `go test -race ./pkg/native/serializers ./pkg/writer ./test/conformance -count=1`
- `golangci-lint run`
- Docker/Linux `hack/verify-spdx.sh --keep /out` with network disabled during the script run
