### PR TITLE
Preserve ADLER32 hashes in SPDX 3 round trips

### DIFF
--- a/api/sbom.proto
+++ b/api/sbom.proto
@@ -592,7 +592,7 @@ enum HashAlgorithm {
   BLAKE3 = 12;
   // MD2 hash algorithm, not supported by SPDX formats.
   MD2 = 13;
-  // Adler-32 hash algorithm, not supported by SPDX formats..
+  // Adler-32 hash algorithm.
   ADLER32 = 14;
   // MD4 hash algorithm, not supported by SPDX formats..
   MD4 = 15;

--- a/pkg/native/unserializers/unserializer_spdx3_test.go
+++ b/pkg/native/unserializers/unserializer_spdx3_test.go
@@ -150,7 +150,8 @@ func TestSPDX3UnserializeElements(t *testing.T) {
 			"validUntilTime": "2026-08-03T00:00:00Z",
 			"verifiedUsing": [
 				{"type": "Hash", "algorithm": "sha256", "hashValue": "abc123"},
-				{"type": "Hash", "algorithm": "adler32", "hashValue": "nope"}
+				{"type": "Hash", "algorithm": "adler32", "hashValue": "0badf00d"},
+				{"type": "Hash", "algorithm": "crystalsDilithium", "hashValue": "nope"}
 			],
 			"externalIdentifier": [
 				{"type": "ExternalIdentifier", "externalIdentifierType": "cpe23", "identifier": "cpe:2.3:a:x"},
@@ -200,7 +201,10 @@ func TestSPDX3UnserializeElements(t *testing.T) {
 
 	// An algorithm or identifier type protobom has no name for is dropped,
 	// and does not displace the ones it does.
-	require.Equal(t, map[int32]string{int32(sbom.HashAlgorithm_SHA256): "abc123"}, pkg.Hashes)
+	require.Equal(t, map[int32]string{
+		int32(sbom.HashAlgorithm_SHA256):  "abc123",
+		int32(sbom.HashAlgorithm_ADLER32): "0badf00d",
+	}, pkg.Hashes)
 	require.Equal(t, map[int32]string{
 		int32(sbom.SoftwareIdentifierType_PURL):  "pkg:generic/a-package@1.2.3",
 		int32(sbom.SoftwareIdentifierType_CPE23): "cpe:2.3:a:x",

--- a/pkg/sbom/hashalgorithm.go
+++ b/pkg/sbom/hashalgorithm.go
@@ -128,6 +128,8 @@ func HashAlgorithmFromSPDX(spdxAlgo common.ChecksumAlgorithm) HashAlgorithm {
 // https://github.com/spdx/spdx-3-model/blob/main/model/Core/Vocabularies/HashAlgorithm.md
 func (ha HashAlgorithm) ToSPDX3() string {
 	switch ha {
+	case HashAlgorithm_ADLER32:
+		return "adler32"
 	case HashAlgorithm_MD4:
 		return "md4"
 	case HashAlgorithm_MD5:
@@ -167,6 +169,8 @@ func (ha HashAlgorithm) ToSPDX3() string {
 // name states. It is the inverse of [HashAlgorithm.ToSPDX3].
 func HashAlgorithmFromSPDX3(spdxAlgo string) HashAlgorithm {
 	switch spdxAlgo {
+	case "adler32":
+		return HashAlgorithm_ADLER32
 	case "md4":
 		return HashAlgorithm_MD4
 	case "md5":
@@ -198,7 +202,7 @@ func HashAlgorithmFromSPDX3(spdxAlgo string) HashAlgorithm {
 	case "blake3":
 		return HashAlgorithm_BLAKE3
 	default:
-		// TODO(degradation): the SPDX 3 vocabulary also names adler32,
+		// TODO(degradation): the SPDX 3 vocabulary also names
 		// crystalsDilithium, crystalsKyber, falcon and sha3_224, which
 		// protobom has no algorithm for.
 		return HashAlgorithm_UNKNOWN

--- a/pkg/sbom/hashalgorithm_test.go
+++ b/pkg/sbom/hashalgorithm_test.go
@@ -14,6 +14,9 @@ import (
 // single mistyped name, which is the kind of mistake that reads correct.
 func TestHashAlgorithmSPDX3RoundTrip(t *testing.T) {
 	t.Parallel()
+	require.Equal(t, "adler32", HashAlgorithm_ADLER32.ToSPDX3())
+	require.Equal(t, HashAlgorithm_ADLER32, HashAlgorithmFromSPDX3("adler32"))
+
 	named := 0
 	for algo := range HashAlgorithm_name {
 		name := HashAlgorithm(algo).ToSPDX3()

--- a/pkg/sbom/sbom.pb.go
+++ b/pkg/sbom/sbom.pb.go
@@ -61,7 +61,7 @@ const (
 	HashAlgorithm_BLAKE3 HashAlgorithm = 12
 	// MD2 hash algorithm, not supported by SPDX formats.
 	HashAlgorithm_MD2 HashAlgorithm = 13
-	// Adler-32 hash algorithm, not supported by SPDX formats..
+	// Adler-32 hash algorithm.
 	HashAlgorithm_ADLER32 HashAlgorithm = 14
 	// MD4 hash algorithm, not supported by SPDX formats..
 	HashAlgorithm_MD4 HashAlgorithm = 15

--- a/test/conformance/roundtrip_spdx3_test.go
+++ b/test/conformance/roundtrip_spdx3_test.go
@@ -244,8 +244,22 @@ func TestRoundTripSPDX3EveryVocabulary(t *testing.T) {
 	})
 
 	t.Run("hash algorithms", func(t *testing.T) {
+		// ADLER32 is named explicitly because it was previously present in
+		// protobom and the SPDX 3 vocabulary, but missing from this mapping.
+		t.Run("ADLER32", func(t *testing.T) {
+			got := roundTripNode(t, &sbom.Node{
+				Id: vocabularyNS + "#n", Type: sbom.Node_PACKAGE, Name: "n",
+				Hashes:      map[int32]string{int32(sbom.HashAlgorithm_ADLER32): "0badf00d"},
+				Identifiers: map[int32]string{},
+			})
+			require.Equal(t, map[int32]string{int32(sbom.HashAlgorithm_ADLER32): "0badf00d"}, got.Hashes)
+		})
+
 		for value, name := range sbom.HashAlgorithm_name {
 			algo := sbom.HashAlgorithm(value)
+			if algo == sbom.HashAlgorithm_ADLER32 {
+				continue
+			}
 			if algo.ToSPDX3() == "" {
 				continue
 			}


### PR DESCRIPTION
This fixes the SPDX 3 hash algorithm mapping for `HashAlgorithm_ADLER32`.

`HashAlgorithm_ADLER32` already exists in protobom and is mapped for SPDX 2.x, and SPDX 3 names the algorithm as `adler32`. The SPDX 3 writer skipped it because `ToSPDX3()` returned `""`; the reader also dropped incoming `{"algorithm":"adler32"}` hashes because `HashAlgorithmFromSPDX3` returned `UNKNOWN`.

This adds the `adler32` mapping both ways and updates the SPDX 3 unserializer/conformance tests so the hash survives input parsing and a write/read round trip. I also left an unsupported SPDX 3 algorithm in the reader test to keep the drop path covered.

Checked:
- `go test ./pkg/sbom ./pkg/native/serializers ./pkg/native/unserializers ./test/conformance/... -count=1 -v`
- `go test ./pkg/sbom ./pkg/native/unserializers ./test/conformance/... -run 'TestHashAlgorithmSPDX3RoundTrip|TestSPDX3UnserializeElements|TestRoundTripSPDX3EveryVocabulary/hash_algorithms/ADLER32' -count=20`
- `go test ./... -count=1`
- `go test -race ./pkg/sbom ./pkg/native/serializers ./pkg/native/unserializers ./test/conformance/... -count=1`
- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...` (v2.12.0)
- `hack/verify-spdx.sh --keep /tmp/spdx-output` (Docker/Linux, rerun with `--network none` after caches were populated)
- `hack/verify-proto.sh`
- `hack/verify-fakes.sh`
