### PR TITLE
Make the filesystem storage backend usable and non-fatal

### DIFF
--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/release-utils/helpers"
 
@@ -49,19 +48,27 @@ func (fs *FileSystem) Store(bom *sbom.Document, opts *StoreOptions) error {
 	if opts == nil {
 		opts = &StoreOptions{}
 	}
+	if fs.Options.Path == "" {
+		return errors.New("unable to persist document: filesystem backend data dir not set")
+	}
+	if bom == nil {
+		return errors.New("unable to persist document: document is nil")
+	}
 
 	i, err := os.Stat(fs.Options.Path)
 	switch {
 	// Check if the data directory exists
 	case err != nil && errors.Is(err, os.ErrNotExist):
-		if err := os.MkdirAll(fs.Options.Path, os.FileMode(0o644)); err != nil {
-			return fmt.Errorf("error creating filesystem backend storage directory")
+		// The directory needs the execute bits or nothing can be
+		// written into it afterwards.
+		if err := os.MkdirAll(fs.Options.Path, os.FileMode(0o755)); err != nil {
+			return fmt.Errorf("creating filesystem backend storage directory: %w", err)
 		}
 	case err != nil:
 		// Any other errors are a true error
 		return fmt.Errorf("checking filesystem backend path directory: %w", err)
 	case !i.IsDir():
-		return fmt.Errorf("the specified filsystem backend patch is not a directory")
+		return errors.New("the specified filesystem backend path is not a directory")
 	}
 
 	if bom.Metadata == nil || bom.Metadata.Id == "" {
@@ -91,7 +98,8 @@ func (fs *FileSystem) Store(bom *sbom.Document, opts *StoreOptions) error {
 }
 
 // Retrieve implements the storage backend Retrieve interface. It looks for a
-// protobom document in a directory
+// protobom document in a directory. A document that was never stored is
+// reported with an error wrapping os.ErrNotExist.
 func (fs *FileSystem) Retrieve(id string, _ *RetrieveOptions) (*sbom.Document, error) {
 	if fs.Options.Path == "" {
 		return nil, fmt.Errorf("unable to retrieve SBOM data: filesystem backend data dir not set")
@@ -107,11 +115,11 @@ func (fs *FileSystem) Retrieve(id string, _ *RetrieveOptions) (*sbom.Document, e
 
 	data, err := os.ReadFile(filepath.Join(fs.Options.Path, filename))
 	if err != nil {
-		logrus.Fatal(fmt.Errorf("reading protobom data from disk: %w", err))
+		return nil, fmt.Errorf("reading protobom data from disk: %w", err)
 	}
 	bom := &sbom.Document{}
 	if err := proto.Unmarshal(data, bom); err != nil {
-		logrus.Fatal(fmt.Errorf("unmarshaling protobom data: %w", err))
+		return nil, fmt.Errorf("unmarshaling protobom data: %w", err)
 	}
 
 	return bom, nil

--- a/pkg/storage/filesystem_test.go
+++ b/pkg/storage/filesystem_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -47,4 +48,90 @@ func TestFileSystem(t *testing.T) {
 			require.Equal(t, tc.testDoc.Metadata.Id, doc.Metadata.Id)
 		})
 	}
+}
+
+// Storing into a directory that does not exist yet must create it usable:
+// a directory without its execute bits cannot be written into afterwards.
+func TestFileSystemCreatesDataDir(t *testing.T) {
+	t.Parallel()
+	fs := NewFileSystem()
+	fs.Options.Path = filepath.Join(t.TempDir(), "new", "data")
+
+	doc := &sbom.Document{Metadata: &sbom.Metadata{Id: "created-dir"}}
+	require.NoError(t, fs.Store(doc, nil))
+
+	info, err := os.Stat(fs.Options.Path)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	require.NotZero(t, info.Mode().Perm()&0o100, "data dir must be traversable by its owner")
+
+	got, err := fs.Retrieve("created-dir", nil)
+	require.NoError(t, err)
+	require.Equal(t, "created-dir", got.Metadata.Id)
+}
+
+func TestFileSystemStoreErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no data dir configured", func(t *testing.T) {
+		t.Parallel()
+		err := NewFileSystem().Store(&sbom.Document{Metadata: &sbom.Metadata{Id: "x"}}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("nil document", func(t *testing.T) {
+		t.Parallel()
+		fs := NewFileSystem()
+		fs.Options.Path = t.TempDir()
+		require.Error(t, fs.Store(nil, nil))
+	})
+
+	t.Run("path is a file", func(t *testing.T) {
+		t.Parallel()
+		fs := NewFileSystem()
+		fs.Options.Path = filepath.Join(t.TempDir(), "file")
+		require.NoError(t, os.WriteFile(fs.Options.Path, []byte("x"), 0o600))
+		require.Error(t, fs.Store(&sbom.Document{Metadata: &sbom.Metadata{Id: "x"}}, nil))
+	})
+
+	t.Run("no clobber", func(t *testing.T) {
+		t.Parallel()
+		fs := NewFileSystem()
+		fs.Options.Path = t.TempDir()
+		doc := &sbom.Document{Metadata: &sbom.Metadata{Id: "x"}}
+		require.NoError(t, fs.Store(doc, nil))
+		require.Error(t, fs.Store(doc, &StoreOptions{NoClobber: true}))
+		require.NoError(t, fs.Store(doc, &StoreOptions{NoClobber: false}))
+	})
+}
+
+// Retrieve must report problems as errors: a library must never exit the
+// process on a missing or corrupt document.
+func TestFileSystemRetrieveErrors(t *testing.T) {
+	t.Parallel()
+	fs := NewFileSystem()
+	fs.Options.Path = t.TempDir()
+
+	t.Run("missing document", func(t *testing.T) {
+		t.Parallel()
+		doc, err := fs.Retrieve("never-stored", nil)
+		require.ErrorIs(t, err, os.ErrNotExist)
+		require.Nil(t, doc)
+	})
+
+	t.Run("corrupt document", func(t *testing.T) {
+		t.Parallel()
+		filename, err := generateDocFileName("corrupt")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(fs.Options.Path, filename), []byte{0xff, 0xff, 0xff}, 0o600))
+		doc, err := fs.Retrieve("corrupt", nil)
+		require.Error(t, err)
+		require.Nil(t, doc)
+	})
+
+	t.Run("empty id", func(t *testing.T) {
+		t.Parallel()
+		_, err := fs.Retrieve("", nil)
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
Store created a missing data directory with mode 0644. Without its execute bits the directory cannot be entered, so the write that followed failed with permission denied for any non-root user: the backend only worked when the directory already existed.

Retrieve called logrus.Fatal on a missing or corrupt document, exiting the caller's process from inside a library. Return errors instead; a document that was never stored is reported wrapping os.ErrNotExist.