### PR TITLE
Add NodeList diff support

### DIFF
--- a/pkg/sbom/diff.go
+++ b/pkg/sbom/diff.go
@@ -21,18 +21,46 @@ type NodeDiff struct {
 	Node2 *Node
 }
 
+// DiffOption adjusts how the diff functions compare protobom data.
+type DiffOption func(*diffOptions)
+
+// diffOptions captures the adjustments that DiffOptions make to a diff.
+type diffOptions struct {
+	compareIDs bool
+}
+
+// WithIDs returns a DiffOption that makes the diff functions treat node ID
+// changes as content changes. By default IDs are ignored when comparing: an
+// ID identifies a node within a document rather than describing the software,
+// and varies across formats and tools describing the same component.
+func WithIDs() DiffOption {
+	return func(o *diffOptions) {
+		o.compareIDs = true
+	}
+}
+
 // Diff analyses a node and returns a a new node populated with all fields
-// that are different in n2 from n. If no changes are found, Diff returns nil
-func (n *Node) Diff(n2 *Node) *NodeDiff {
+// that are different in n2 from n. If no changes are found, Diff returns nil.
+// Node IDs are not compared unless the [WithIDs] option is passed.
+func (n *Node) Diff(n2 *Node, options ...DiffOption) *NodeDiff {
+	opts := &diffOptions{}
+	for _, apply := range options {
+		apply(opts)
+	}
+
 	nd := NodeDiff{
 		Added:   &Node{},
 		Removed: &Node{},
 	}
 
-	a, r, c := diff(n.Id, n2.Id)
-	nd.Added.Id = a
-	nd.Removed.Id = r
-	nd.DiffCount += c
+	var a, r string
+	var c int
+	if opts.compareIDs {
+		a, r, c = diff(n.Id, n2.Id)
+		nd.Added.Id = a
+		nd.Removed.Id = r
+		nd.DiffCount += c
+	}
 
 	if n.Type != n2.Type {
 		nd.Added.Type = n2.Type
@@ -203,11 +231,15 @@ type NodeListDiff struct {
 // Paired nodes with differing data are reported as [NodeDiff] entries in
 // Modified, with Node1 and Node2 pointing to the paired nodes.
 //
+// While node IDs are used to pair nodes, an ID change in a pair matched by
+// software identity does not count as a change unless the [WithIDs] option
+// is passed.
+//
 // Edges are compared per source node and edge type after translating the IDs
 // of paired nodes in nl2 into their equivalents in nl. The edges in the
 // report carry only the destinations that changed. Root element changes are
 // reported the same way, in the receiver's ID space.
-func (nl *NodeList) Diff(nl2 *NodeList) *NodeListDiff {
+func (nl *NodeList) Diff(nl2 *NodeList, options ...DiffOption) *NodeListDiff {
 	if nl2 == nil {
 		nl2 = &NodeList{}
 	}
@@ -266,7 +298,7 @@ func (nl *NodeList) Diff(nl2 *NodeList) *NodeListDiff {
 			d.Removed = append(d.Removed, n)
 			continue
 		}
-		if nd := n.Diff(n2); nd != nil {
+		if nd := n.Diff(n2, options...); nd != nil {
 			nd.Node1 = n
 			nd.Node2 = n2
 			d.Modified = append(d.Modified, nd)

--- a/pkg/sbom/diff.go
+++ b/pkg/sbom/diff.go
@@ -1,6 +1,9 @@
 package sbom
 
 import (
+	"cmp"
+	"maps"
+	"slices"
 	"time"
 
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
@@ -10,6 +13,12 @@ type NodeDiff struct {
 	Added     *Node
 	Removed   *Node
 	DiffCount int
+
+	// Node1 and Node2 reference the pair of nodes the diff describes. They
+	// are populated by NodeList.Diff, where a diff can belong to one of many
+	// matched pairs; Node.Diff leaves them nil.
+	Node1 *Node
+	Node2 *Node
 }
 
 // Diff analyses a node and returns a a new node populated with all fields
@@ -159,6 +168,219 @@ func (n *Node) Diff(n2 *Node) *NodeDiff {
 		return &nd
 	}
 	return nil
+}
+
+// NodeListDiff captures the differences between two NodeLists. Nodes present
+// in only one of the lists are collected in Added and Removed. Nodes found in
+// both lists whose data differs are captured as NodeDiffs in Modified. Edge
+// and root element changes are expressed in the ID space of the NodeList the
+// diff was computed from (the receiver of NodeList.Diff).
+type NodeListDiff struct {
+	Added    []*Node
+	Removed  []*Node
+	Modified []*NodeDiff
+
+	EdgesAdded   []*Edge
+	EdgesRemoved []*Edge
+
+	RootElementsAdded   []string
+	RootElementsRemoved []string
+
+	// DiffCount totals the changes in the report: one per added or removed
+	// node, edge delta and root element change, plus the DiffCount of each
+	// modified node.
+	DiffCount int
+}
+
+// Diff compares the NodeList to another (nl2) and returns a NodeListDiff
+// describing the changes that transform nl into nl2. If the lists are
+// equivalent, Diff returns nil. A nil nl2 is treated as an empty NodeList.
+//
+// Nodes are paired across the two lists first by ID and then, for nodes
+// without an ID match, by software identity using [NodeList.GetMatchingNode]
+// (hashes, then purl). A node that matches more than one candidate is left
+// unpaired and reported as added or removed rather than guessing a pair.
+// Paired nodes with differing data are reported as [NodeDiff] entries in
+// Modified, with Node1 and Node2 pointing to the paired nodes.
+//
+// Edges are compared per source node and edge type after translating the IDs
+// of paired nodes in nl2 into their equivalents in nl. The edges in the
+// report carry only the destinations that changed. Root element changes are
+// reported the same way, in the receiver's ID space.
+func (nl *NodeList) Diff(nl2 *NodeList) *NodeListDiff {
+	if nl2 == nil {
+		nl2 = &NodeList{}
+	}
+
+	d := &NodeListDiff{
+		Added:        []*Node{},
+		Removed:      []*Node{},
+		Modified:     []*NodeDiff{},
+		EdgesAdded:   []*Edge{},
+		EdgesRemoved: []*Edge{},
+	}
+
+	// Pair the nodes of the two lists, first by ID:
+	pairs := map[string]*Node{}
+	matched2 := map[string]struct{}{}
+	index2 := nl2.indexNodes()
+	for _, n := range nl.Nodes {
+		if n2, ok := index2[n.Id]; ok {
+			pairs[n.Id] = n2
+			matched2[n2.Id] = struct{}{}
+		}
+	}
+
+	// ...then by software identity. Only nodes not already paired are
+	// eligible and each node can be claimed by a single pair.
+	remaining := &NodeList{}
+	for _, n2 := range nl2.Nodes {
+		if _, ok := matched2[n2.Id]; !ok {
+			remaining.Nodes = append(remaining.Nodes, n2)
+		}
+	}
+	for _, n := range nl.Nodes {
+		if _, ok := pairs[n.Id]; ok {
+			continue
+		}
+		// An ambiguous match (ErrorMoreThanOneMatch) leaves the node
+		// unpaired to be reported as added and removed.
+		n2, err := remaining.GetMatchingNode(n)
+		if err != nil || n2 == nil {
+			continue
+		}
+		pairs[n.Id] = n2
+		matched2[n2.Id] = struct{}{}
+		for i := range remaining.Nodes {
+			if remaining.Nodes[i].Id == n2.Id {
+				remaining.Nodes = slices.Delete(remaining.Nodes, i, i+1)
+				break
+			}
+		}
+	}
+
+	// Classify the nodes based on the pairings:
+	for _, n := range nl.Nodes {
+		n2, ok := pairs[n.Id]
+		if !ok {
+			d.Removed = append(d.Removed, n)
+			continue
+		}
+		if nd := n.Diff(n2); nd != nil {
+			nd.Node1 = n
+			nd.Node2 = n2
+			d.Modified = append(d.Modified, nd)
+			d.DiffCount += nd.DiffCount
+		}
+	}
+	for _, n2 := range nl2.Nodes {
+		if _, ok := matched2[n2.Id]; !ok {
+			d.Added = append(d.Added, n2)
+		}
+	}
+
+	// Translation map from nl2's ID space to the receiver's
+	idmap := map[string]string{}
+	for id1, n2 := range pairs {
+		idmap[n2.Id] = id1
+	}
+
+	d.EdgesAdded, d.EdgesRemoved = diffEdges(nl.Edges, nl2.Edges, idmap)
+
+	roots2 := make([]string, 0, len(nl2.RootElements))
+	for _, id := range nl2.RootElements {
+		roots2 = append(roots2, translateID(idmap, id))
+	}
+	d.RootElementsAdded, d.RootElementsRemoved, _ = diffSlice(nl.RootElements, roots2)
+
+	d.DiffCount += len(d.Added) + len(d.Removed) +
+		len(d.EdgesAdded) + len(d.EdgesRemoved) +
+		len(d.RootElementsAdded) + len(d.RootElementsRemoved)
+
+	if d.DiffCount > 0 {
+		return d
+	}
+	return nil
+}
+
+// edgeSourceKey identifies a group of edge destinations by origin and type
+type edgeSourceKey struct {
+	from     string
+	edgeType Edge_Type
+}
+
+// diffEdges compares two edge lists and returns the added and removed
+// relationships. Edges are compared per source node and type, so the returned
+// edges carry only the destinations that changed. IDs in edges2 are
+// translated through idmap before comparing.
+func diffEdges(edges1, edges2 []*Edge, idmap map[string]string) (added, removed []*Edge) {
+	added = []*Edge{}
+	removed = []*Edge{}
+
+	agg1 := aggregateEdges(edges1, nil)
+	agg2 := aggregateEdges(edges2, idmap)
+
+	keys := slices.Collect(maps.Keys(agg1))
+	for k := range agg2 {
+		if _, ok := agg1[k]; !ok {
+			keys = append(keys, k)
+		}
+	}
+	slices.SortFunc(keys, func(a, b edgeSourceKey) int {
+		return cmp.Or(
+			cmp.Compare(a.from, b.from),
+			cmp.Compare(a.edgeType, b.edgeType),
+		)
+	})
+
+	for _, k := range keys {
+		addedTos := []string{}
+		removedTos := []string{}
+		for to := range agg2[k] {
+			if _, ok := agg1[k][to]; !ok {
+				addedTos = append(addedTos, to)
+			}
+		}
+		for to := range agg1[k] {
+			if _, ok := agg2[k][to]; !ok {
+				removedTos = append(removedTos, to)
+			}
+		}
+		if len(addedTos) > 0 {
+			slices.Sort(addedTos)
+			added = append(added, &Edge{From: k.from, Type: k.edgeType, To: addedTos})
+		}
+		if len(removedTos) > 0 {
+			slices.Sort(removedTos)
+			removed = append(removed, &Edge{From: k.from, Type: k.edgeType, To: removedTos})
+		}
+	}
+	return added, removed
+}
+
+// aggregateEdges collapses a list of edges into destination sets indexed by
+// source node and edge type, translating IDs through idmap.
+func aggregateEdges(edges []*Edge, idmap map[string]string) map[edgeSourceKey]map[string]struct{} {
+	agg := map[edgeSourceKey]map[string]struct{}{}
+	for _, e := range edges {
+		k := edgeSourceKey{from: translateID(idmap, e.From), edgeType: e.Type}
+		if _, ok := agg[k]; !ok {
+			agg[k] = map[string]struct{}{}
+		}
+		for _, to := range e.To {
+			agg[k][translateID(idmap, to)] = struct{}{}
+		}
+	}
+	return agg
+}
+
+// translateID returns the equivalent of id in the ID space idmap translates
+// to, or id itself when it has no translation.
+func translateID(idmap map[string]string, id string) string {
+	if tid, ok := idmap[id]; ok {
+		return tid
+	}
+	return id
 }
 
 type Flattenable interface {

--- a/pkg/sbom/diff_test.go
+++ b/pkg/sbom/diff_test.go
@@ -260,6 +260,253 @@ func TestNodeDiff(t *testing.T) {
 	}
 }
 
+// testDiffNodeList builds the NodeList the NodeList.Diff tests start from:
+// an application depending on two libraries.
+func testDiffNodeList() *NodeList {
+	return &NodeList{
+		Nodes: []*Node{
+			{
+				Id:      "node-1",
+				Type:    Node_PACKAGE,
+				Name:    "app",
+				Version: "1.0.0",
+				Identifiers: map[int32]string{
+					int32(SoftwareIdentifierType_PURL): "pkg:generic/app@1.0.0",
+				},
+				Hashes: map[int32]string{
+					int32(HashAlgorithm_SHA256): "6a19a4bb32f4bd925e26f4a5932affe8757dfa1a90c1d1d32a3f0b6f42c2bcf0",
+				},
+			},
+			{
+				Id:      "node-2",
+				Type:    Node_PACKAGE,
+				Name:    "libone",
+				Version: "2.1.0",
+				Identifiers: map[int32]string{
+					int32(SoftwareIdentifierType_PURL): "pkg:generic/libone@2.1.0",
+				},
+				Hashes: map[int32]string{
+					int32(HashAlgorithm_SHA256): "0f9f5c1c3b6a9d5f6f1f4b1a9a4b1b0a3a2c1d1e2f30415263748596a7b8c9d0",
+				},
+			},
+			{
+				Id:      "node-3",
+				Type:    Node_PACKAGE,
+				Name:    "libtwo",
+				Version: "0.9.0",
+				Identifiers: map[int32]string{
+					int32(SoftwareIdentifierType_PURL): "pkg:generic/libtwo@0.9.0",
+				},
+				Hashes: map[int32]string{
+					int32(HashAlgorithm_SHA256): "d6f2b1a0c9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2",
+				},
+			},
+		},
+		Edges: []*Edge{
+			{From: "node-1", Type: Edge_dependsOn, To: []string{"node-2", "node-3"}},
+		},
+		RootElements: []string{"node-1"},
+	}
+}
+
+func TestNodeListDiff(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		prepare func(sut, other *NodeList)
+		// check verifies the resulting diff. A nil check expects a nil diff.
+		check func(t *testing.T, d *NodeListDiff)
+	}{
+		{
+			name:    "no change",
+			prepare: func(sut, other *NodeList) {},
+			check:   nil,
+		},
+		{
+			name: "node added",
+			prepare: func(sut, other *NodeList) {
+				other.Nodes = append(other.Nodes, &Node{Id: "node-4", Name: "libthree"})
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Len(t, d.Added, 1)
+				require.Equal(t, "node-4", d.Added[0].Id)
+				require.Empty(t, d.Removed)
+				require.Empty(t, d.Modified)
+				require.Equal(t, 1, d.DiffCount)
+			},
+		},
+		{
+			name: "node removed",
+			prepare: func(sut, other *NodeList) {
+				other.Nodes = other.Nodes[0:2]
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Empty(t, d.Added)
+				require.Len(t, d.Removed, 1)
+				require.Equal(t, "node-3", d.Removed[0].Id)
+				require.Empty(t, d.Modified)
+				require.Equal(t, 1, d.DiffCount)
+			},
+		},
+		{
+			name: "node modified",
+			prepare: func(sut, other *NodeList) {
+				other.Nodes[1].Version = "2.2.0"
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Empty(t, d.Added)
+				require.Empty(t, d.Removed)
+				require.Len(t, d.Modified, 1)
+				require.Equal(t, "node-2", d.Modified[0].Node1.Id)
+				require.Equal(t, "node-2", d.Modified[0].Node2.Id)
+				require.Equal(t, "2.2.0", d.Modified[0].Added.Version)
+				require.Equal(t, 1, d.Modified[0].DiffCount)
+				require.Equal(t, 1, d.DiffCount)
+			},
+		},
+		{
+			name: "node matched by identity across IDs",
+			prepare: func(sut, other *NodeList) {
+				other.Nodes[2].Id = "node-3-renamed"
+				other.Edges[0].To = []string{"node-2", "node-3-renamed"}
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Empty(t, d.Added)
+				require.Empty(t, d.Removed)
+				require.Len(t, d.Modified, 1)
+				require.Equal(t, "node-3", d.Modified[0].Node1.Id)
+				require.Equal(t, "node-3-renamed", d.Modified[0].Node2.Id)
+				require.Equal(t, "node-3-renamed", d.Modified[0].Added.Id)
+				// The edges must not report changes as the renamed node's
+				// ID translates back to its match in the receiver
+				require.Empty(t, d.EdgesAdded)
+				require.Empty(t, d.EdgesRemoved)
+				require.Equal(t, 1, d.DiffCount)
+			},
+		},
+		{
+			name: "ambiguous identity match reports add and remove",
+			prepare: func(sut, other *NodeList) {
+				sut.Nodes = append(sut.Nodes, &Node{
+					Id: "amb-1",
+					Identifiers: map[int32]string{
+						int32(SoftwareIdentifierType_PURL): "pkg:generic/dupe@1.0.0",
+					},
+				})
+				for _, id := range []string{"amb-2", "amb-3"} {
+					other.Nodes = append(other.Nodes, &Node{
+						Id: id,
+						Identifiers: map[int32]string{
+							int32(SoftwareIdentifierType_PURL): "pkg:generic/dupe@1.0.0",
+						},
+					})
+				}
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Len(t, d.Added, 2)
+				require.Equal(t, "amb-2", d.Added[0].Id)
+				require.Equal(t, "amb-3", d.Added[1].Id)
+				require.Len(t, d.Removed, 1)
+				require.Equal(t, "amb-1", d.Removed[0].Id)
+				require.Empty(t, d.Modified)
+				require.Equal(t, 3, d.DiffCount)
+			},
+		},
+		{
+			name: "edge destination added",
+			prepare: func(sut, other *NodeList) {
+				other.Nodes = append(other.Nodes, &Node{Id: "node-4", Name: "libthree"})
+				other.Edges[0].To = append(other.Edges[0].To, "node-4")
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Len(t, d.Added, 1)
+				require.Len(t, d.EdgesAdded, 1)
+				require.True(t, d.EdgesAdded[0].Equal(
+					&Edge{From: "node-1", Type: Edge_dependsOn, To: []string{"node-4"}},
+				), d.EdgesAdded[0].flatString())
+				require.Empty(t, d.EdgesRemoved)
+				require.Equal(t, 2, d.DiffCount)
+			},
+		},
+		{
+			name: "edge destination removed",
+			prepare: func(sut, other *NodeList) {
+				other.Nodes = other.Nodes[0:2]
+				other.Edges[0].To = []string{"node-2"}
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Len(t, d.Removed, 1)
+				require.Empty(t, d.EdgesAdded)
+				require.Len(t, d.EdgesRemoved, 1)
+				require.True(t, d.EdgesRemoved[0].Equal(
+					&Edge{From: "node-1", Type: Edge_dependsOn, To: []string{"node-3"}},
+				), d.EdgesRemoved[0].flatString())
+				require.Equal(t, 2, d.DiffCount)
+			},
+		},
+		{
+			name: "edge of new type added",
+			prepare: func(sut, other *NodeList) {
+				other.Edges = append(other.Edges, &Edge{
+					From: "node-2", Type: Edge_contains, To: []string{"node-3"},
+				})
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Len(t, d.EdgesAdded, 1)
+				require.True(t, d.EdgesAdded[0].Equal(
+					&Edge{From: "node-2", Type: Edge_contains, To: []string{"node-3"}},
+				), d.EdgesAdded[0].flatString())
+				require.Equal(t, 1, d.DiffCount)
+			},
+		},
+		{
+			name: "root element added",
+			prepare: func(sut, other *NodeList) {
+				other.RootElements = append(other.RootElements, "node-2")
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Equal(t, []string{"node-2"}, d.RootElementsAdded)
+				require.Empty(t, d.RootElementsRemoved)
+				require.Equal(t, 1, d.DiffCount)
+			},
+		},
+		{
+			name: "root element replaced",
+			prepare: func(sut, other *NodeList) {
+				other.RootElements = []string{"node-2"}
+			},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Equal(t, []string{"node-2"}, d.RootElementsAdded)
+				require.Equal(t, []string{"node-1"}, d.RootElementsRemoved)
+				require.Equal(t, 2, d.DiffCount)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sut := testDiffNodeList()
+			other := testDiffNodeList()
+			tc.prepare(sut, other)
+			result := sut.Diff(other)
+			if tc.check == nil {
+				require.Nil(t, result)
+				return
+			}
+			require.NotNil(t, result)
+			tc.check(t, result)
+		})
+	}
+}
+
+func TestNodeListDiffNil(t *testing.T) {
+	sut := testDiffNodeList()
+	d := sut.Diff(nil)
+	require.NotNil(t, d)
+	require.Empty(t, d.Added)
+	require.Len(t, d.Removed, 3)
+	require.Len(t, d.EdgesRemoved, 1)
+	require.Equal(t, []string{"node-1"}, d.RootElementsRemoved)
+	require.Equal(t, 5, d.DiffCount)
+}
+
 func TestDiffString(t *testing.T) {
 	for _, tc := range []struct {
 		name            string

--- a/pkg/sbom/diff_test.go
+++ b/pkg/sbom/diff_test.go
@@ -62,6 +62,7 @@ func TestNodeDiff(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		prepare  func(*Node, *Node)
+		options  []DiffOption
 		sut      *Node
 		node     *Node
 		expected *NodeDiff
@@ -72,10 +73,18 @@ func TestNodeDiff(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "alter node id",
+			name: "alter node id ignored by default",
 			prepare: func(sutNode, newNode *Node) {
 				newNode.Id = "modified"
 			},
+			expected: nil,
+		},
+		{
+			name: "alter node id with WithIDs",
+			prepare: func(sutNode, newNode *Node) {
+				newNode.Id = "modified"
+			},
+			options: []DiffOption{WithIDs()},
 			expected: &NodeDiff{
 				Added: &Node{
 					Id: "modified",
@@ -103,6 +112,21 @@ func TestNodeDiff(t *testing.T) {
 				newNode.Id = "modified"
 				newNode.Name = "newname"
 			},
+			expected: &NodeDiff{
+				Added: &Node{
+					Name: "newname",
+				},
+				Removed:   &Node{},
+				DiffCount: 1,
+			},
+		},
+		{
+			name: "alter node name and id with WithIDs",
+			prepare: func(sutNode, newNode *Node) {
+				newNode.Id = "modified"
+				newNode.Name = "newname"
+			},
+			options: []DiffOption{WithIDs()},
 			expected: &NodeDiff{
 				Added: &Node{
 					Id:   "modified",
@@ -246,7 +270,7 @@ func TestNodeDiff(t *testing.T) {
 			tc.node = testNode.Copy()
 			// The prepare function modifies them for the test
 			tc.prepare(tc.sut, tc.node)
-			result := tc.sut.Diff(tc.node)
+			result := tc.sut.Diff(tc.node, tc.options...)
 			if tc.expected == nil {
 				require.Nil(t, result)
 				return
@@ -313,6 +337,7 @@ func TestNodeListDiff(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		prepare func(sut, other *NodeList)
+		options []DiffOption
 		// check verifies the resulting diff. A nil check expects a nil diff.
 		check func(t *testing.T, d *NodeListDiff)
 	}{
@@ -364,9 +389,33 @@ func TestNodeListDiff(t *testing.T) {
 			},
 		},
 		{
+			name: "node rename alone is no change",
+			prepare: func(sut, other *NodeList) {
+				other.Nodes[2].Id = "node-3-renamed"
+				other.Edges[0].To = []string{"node-2", "node-3-renamed"}
+			},
+			check: nil,
+		},
+		{
+			name: "node rename reported with WithIDs",
+			prepare: func(sut, other *NodeList) {
+				other.Nodes[2].Id = "node-3-renamed"
+				other.Edges[0].To = []string{"node-2", "node-3-renamed"}
+			},
+			options: []DiffOption{WithIDs()},
+			check: func(t *testing.T, d *NodeListDiff) {
+				require.Empty(t, d.Added)
+				require.Empty(t, d.Removed)
+				require.Len(t, d.Modified, 1)
+				require.Equal(t, "node-3-renamed", d.Modified[0].Added.Id)
+				require.Equal(t, 1, d.DiffCount)
+			},
+		},
+		{
 			name: "node matched by identity across IDs",
 			prepare: func(sut, other *NodeList) {
 				other.Nodes[2].Id = "node-3-renamed"
+				other.Nodes[2].Version = "0.9.1"
 				other.Edges[0].To = []string{"node-2", "node-3-renamed"}
 			},
 			check: func(t *testing.T, d *NodeListDiff) {
@@ -375,7 +424,8 @@ func TestNodeListDiff(t *testing.T) {
 				require.Len(t, d.Modified, 1)
 				require.Equal(t, "node-3", d.Modified[0].Node1.Id)
 				require.Equal(t, "node-3-renamed", d.Modified[0].Node2.Id)
-				require.Equal(t, "node-3-renamed", d.Modified[0].Added.Id)
+				require.Equal(t, "0.9.1", d.Modified[0].Added.Version)
+				require.Empty(t, d.Modified[0].Added.Id)
 				// The edges must not report changes as the renamed node's
 				// ID translates back to its match in the receiver
 				require.Empty(t, d.EdgesAdded)
@@ -485,7 +535,7 @@ func TestNodeListDiff(t *testing.T) {
 			sut := testDiffNodeList()
 			other := testDiffNodeList()
 			tc.prepare(sut, other)
-			result := sut.Diff(other)
+			result := sut.Diff(other, tc.options...)
 			if tc.check == nil {
 				require.Nil(t, result)
 				return


### PR DESCRIPTION
This PR adds the missing NodeList.Diff() function. 

At some point two years ago we stopped developing the diffing support for the NodeList. This PR finishes it. It includes a WithIDs option to control if the diff function reports the changed node IDs  (off by default)