### PR TITLE
Graph API updates

### DIFF
--- a/pkg/sbom/diff.go
+++ b/pkg/sbom/diff.go
@@ -112,6 +112,16 @@ func (n *Node) Diff(n2 *Node, options ...DiffOption) *NodeDiff {
 	nd.Removed.SourceInfo = r
 	nd.DiffCount += c
 
+	a, r, c = diff(n.ContentType, n2.ContentType)
+	nd.Added.ContentType = a
+	nd.Removed.ContentType = r
+	nd.DiffCount += c
+
+	if n.FileKind != n2.FileKind {
+		nd.Added.FileKind = n2.FileKind
+		nd.DiffCount++
+	}
+
 	ap, rp, cp := diffSlice(n.PrimaryPurpose, n2.PrimaryPurpose)
 	nd.Added.PrimaryPurpose = ap
 	nd.Removed.PrimaryPurpose = rp

--- a/pkg/sbom/diff_test.go
+++ b/pkg/sbom/diff_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1173,4 +1174,20 @@ func TestDiffIntStrMap(t *testing.T) {
 			require.Equal(t, tc.expectedCount, c)
 		})
 	}
+}
+
+// TestNodeDiffIsComplete clears each field of a full node in turn and checks
+// the diff notices the change. A field added to the proto that Diff does not
+// compare fails here.
+func TestNodeDiffIsComplete(t *testing.T) {
+	full := fullNode()
+	full.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, _ protoreflect.Value) bool {
+		t.Run(string(fd.Name()), func(t *testing.T) {
+			blanked := full.Copy()
+			blanked.ProtoReflect().Clear(fd)
+			require.NotNil(t, blanked.Diff(full, WithIDs()),
+				"Diff does not see a change in %s", fd.Name())
+		})
+		return true
+	})
 }

--- a/pkg/sbom/document_test.go
+++ b/pkg/sbom/document_test.go
@@ -1,6 +1,13 @@
 package sbom_test
 
-import "github.com/protobom/protobom/pkg/sbom"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/protobom/protobom/pkg/sbom"
+)
 
 // Demonstrates how to create a new protobom document and add multiple root nodes representing different software applications.
 // Each root node has distinct properties such as ID, name, version, licenses, etc. These root nodes are then attached to the document.
@@ -34,6 +41,13 @@ func Example_roots() {
 	// Attach both roots to document
 	document.NodeList.AddRootNode(firstRoot)
 	document.NodeList.AddRootNode(secondRoot)
+
+	for _, root := range document.GetRootNodes() {
+		fmt.Println(root.Name)
+	}
+	// Output:
+	// My Software Name
+	// My Second Software Name
 }
 
 // Illustrates how to create a new protobom document and populate its metadata.
@@ -62,6 +76,13 @@ func Example_metadata() {
 			Vendor:  "ACME Corporation",
 		},
 	)
+
+	fmt.Printf(
+		"%s %s by %s\n",
+		document.Metadata.Name, document.Metadata.Version, document.Metadata.Authors[0].Name,
+	)
+	// Output:
+	// My software name v1.0.0 by John Doe
 }
 
 // Showcases how to create a new protobom document, add nodes representing software components,
@@ -105,4 +126,24 @@ func Example_nodes() {
 	document.NodeList.AddNode(firstNode)
 	document.NodeList.AddNode(secondSecond)
 	document.NodeList.AddEdge(edge)
+
+	fmt.Printf(
+		"%d nodes related by %d edge\n",
+		len(document.NodeList.Nodes), len(document.NodeList.Edges),
+	)
+	// Output:
+	// 2 nodes related by 1 edge
+}
+
+// TestDocumentGetRootNodes checks that the document surfaces the root nodes
+// of its nodelist.
+func TestDocumentGetRootNodes(t *testing.T) {
+	document := sbom.NewDocument()
+	root := &sbom.Node{Id: "root", Name: "the app"}
+	document.NodeList.AddRootNode(root)
+	document.NodeList.AddNode(&sbom.Node{Id: "dep", Name: "a dependency"})
+
+	roots := document.GetRootNodes()
+	require.Len(t, roots, 1)
+	require.True(t, root.Equal(roots[0]))
 }

--- a/pkg/sbom/edge_test.go
+++ b/pkg/sbom/edge_test.go
@@ -78,3 +78,14 @@ func TestEdgeEqual(t *testing.T) {
 
 	require.False(t, a.Equal(nil))
 }
+
+// TestEdgePointsTo checks the destination lookup guarding edge merges.
+func TestEdgePointsTo(t *testing.T) {
+	t.Parallel()
+	edge := &Edge{Type: Edge_dependsOn, From: "a", To: []string{"b", "c"}}
+	require.True(t, edge.PointsTo("b"))
+	require.True(t, edge.PointsTo("c"))
+	require.False(t, edge.PointsTo("a"))
+	require.False(t, edge.PointsTo("z"))
+	require.False(t, (&Edge{From: "a"}).PointsTo("b"))
+}

--- a/pkg/sbom/node_test.go
+++ b/pkg/sbom/node_test.go
@@ -708,3 +708,154 @@ func TestMergeEdges(t *testing.T) {
 		})
 	}
 }
+
+// TestNodeEqual checks the node identity primitive: identical content is
+// equal, nil is not, and a change to any compared field breaks equality.
+func TestNodeEqual(t *testing.T) {
+	base := &Node{
+		Id:      "node-1",
+		Type:    Node_PACKAGE,
+		Name:    "test",
+		Version: "1.0.0",
+		Licenses: []string{
+			"Apache-2.0",
+		},
+		Hashes: map[int32]string{
+			int32(HashAlgorithm_SHA256): "d02b22ab7fc76fe2a17e768b180bf5048889dbcae3a6d7e4a889a916848e5d11",
+		},
+		Identifiers: map[int32]string{
+			int32(SoftwareIdentifierType_PURL): "pkg:generic/test@1.0.0",
+		},
+		Suppliers: []*Person{
+			{Name: "ACME Inc", IsOrg: true},
+		},
+	}
+
+	t.Run("equal to a copy of itself", func(t *testing.T) {
+		require.True(t, base.Equal(base.Copy()))
+		require.True(t, base.Copy().Equal(base))
+	})
+
+	t.Run("not equal to nil", func(t *testing.T) {
+		require.False(t, base.Equal(nil))
+	})
+
+	for name, prepare := range map[string]func(*Node){
+		"id":         func(n *Node) { n.Id = "changed" },
+		"type":       func(n *Node) { n.Type = Node_FILE },
+		"name":       func(n *Node) { n.Name = "changed" },
+		"version":    func(n *Node) { n.Version = "2.0.0" },
+		"license":    func(n *Node) { n.Licenses[0] = "MIT" },
+		"hash":       func(n *Node) { n.Hashes[int32(HashAlgorithm_SHA256)] = "changed" },
+		"identifier": func(n *Node) { n.Identifiers[int32(SoftwareIdentifierType_PURL)] = "pkg:generic/other@1.0.0" },
+		"supplier":   func(n *Node) { n.Suppliers[0].Name = "changed" },
+	} {
+		t.Run("not equal on changed "+name, func(t *testing.T) {
+			changed := base.Copy()
+			prepare(changed)
+			require.False(t, base.Equal(changed))
+			require.False(t, changed.Equal(base))
+		})
+	}
+}
+
+// TestNodeHashesMatch checks the hash comparison behind node matching: only
+// the algorithms both sides know are compared, all of them have to agree,
+// and at least one shared algorithm is required for a match.
+func TestNodeHashesMatch(t *testing.T) {
+	sha1 := int32(HashAlgorithm_SHA1)
+	sha256 := int32(HashAlgorithm_SHA256)
+	sha512 := int32(HashAlgorithm_SHA512)
+
+	for name, tc := range map[string]struct {
+		nodeHashes map[int32]string
+		testHashes map[int32]string
+		expected   bool
+	}{
+		"identical single algorithm": {
+			map[int32]string{sha256: "aaa"}, map[int32]string{sha256: "aaa"}, true,
+		},
+		"identical several algorithms": {
+			map[int32]string{sha1: "aaa", sha256: "bbb"},
+			map[int32]string{sha1: "aaa", sha256: "bbb"},
+			true,
+		},
+		"extra algorithms on the test side are ignored": {
+			map[int32]string{sha256: "aaa"},
+			map[int32]string{sha256: "aaa", sha512: "ccc"},
+			true,
+		},
+		"extra algorithms on the node are ignored": {
+			map[int32]string{sha256: "aaa", sha512: "ccc"},
+			map[int32]string{sha256: "aaa"},
+			true,
+		},
+		"a shared algorithm disagreeing breaks the match": {
+			map[int32]string{sha1: "aaa", sha256: "bbb"},
+			map[int32]string{sha1: "aaa", sha256: "changed"},
+			false,
+		},
+		"no shared algorithms is no match": {
+			map[int32]string{sha1: "aaa"}, map[int32]string{sha256: "bbb"}, false,
+		},
+		"empty node hashes is no match": {
+			map[int32]string{}, map[int32]string{sha256: "aaa"}, false,
+		},
+		"empty test hashes is no match": {
+			map[int32]string{sha256: "aaa"}, map[int32]string{}, false,
+		},
+		"both empty is no match": {
+			map[int32]string{}, map[int32]string{}, false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			node := &Node{Hashes: tc.nodeHashes}
+			require.Equal(t, tc.expected, node.HashesMatch(tc.testHashes))
+		})
+	}
+}
+
+// TestNodeChecksum checks the checksum backing NodeList.Equal and the
+// generated identifiers: stable for equal content, changed by any change.
+func TestNodeChecksum(t *testing.T) {
+	node := &Node{
+		Id:      "node-1",
+		Name:    "test",
+		Version: "1.0.0",
+		Hashes:  map[int32]string{int32(HashAlgorithm_SHA256): "aaa"},
+	}
+
+	sum := node.Checksum()
+	require.Len(t, sum, 64, "the checksum is a sha256 hex string")
+	require.Equal(t, sum, node.Copy().Checksum(), "equal content produces an equal checksum")
+
+	changed := node.Copy()
+	changed.Version = "2.0.0"
+	require.NotEqual(t, sum, changed.Checksum())
+}
+
+// TestNodePurl checks reading the node's package URL: only packages have
+// one, and only when the purl identifier is set.
+func TestNodePurl(t *testing.T) {
+	purl := "pkg:generic/test@1.0.0"
+
+	node := &Node{
+		Id:   "node-1",
+		Type: Node_PACKAGE,
+		Identifiers: map[int32]string{
+			int32(SoftwareIdentifierType_PURL): purl,
+		},
+	}
+	require.Equal(t, PackageURL(purl), node.Purl())
+
+	file := &Node{
+		Id:   "file-1",
+		Type: Node_FILE,
+		Identifiers: map[int32]string{
+			int32(SoftwareIdentifierType_PURL): purl,
+		},
+	}
+	require.Equal(t, PackageURL(""), file.Purl(), "files have no package URL")
+
+	require.Equal(t, PackageURL(""), (&Node{Type: Node_PACKAGE}).Purl())
+}

--- a/pkg/sbom/node_test.go
+++ b/pkg/sbom/node_test.go
@@ -922,3 +922,146 @@ func TestAugmentIsComplete(t *testing.T) {
 	set.Augment(other)
 	require.True(t, fullNode().Equal(set), "Augment must not overwrite set fields")
 }
+
+func TestNodeAncestors(t *testing.T) {
+	sutID := "mynode"
+	for _, tc := range []struct {
+		name                string
+		sut                 *NodeList
+		expectedNodesLength int
+		depth               int
+	}{
+		{
+			// Zero depth should return no nodes but the queried one
+			name: "depth-zero",
+			sut: &NodeList{
+				Nodes:        []*Node{{Id: sutID}, {Id: "parent"}},
+				Edges:        []*Edge{{Type: Edge_contains, From: "parent", To: []string{sutID}}},
+				RootElements: []string{"parent"},
+			},
+			expectedNodesLength: 1,
+			depth:               0,
+		},
+		{
+			// A chain of three ancestors:
+			//
+			//   root -> mid -> parent -> mynode
+			//
+			// walked one level up.
+			name: "chain-depth-one",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: sutID}, {Id: "parent"}, {Id: "mid"}, {Id: "root"}},
+				Edges: []*Edge{
+					{Type: Edge_contains, From: "root", To: []string{"mid"}},
+					{Type: Edge_contains, From: "mid", To: []string{"parent"}},
+					{Type: Edge_contains, From: "parent", To: []string{sutID}},
+				},
+				RootElements: []string{"root"},
+			},
+			expectedNodesLength: 2,
+			depth:               1,
+		},
+		{
+			// The same chain walked all the way to the top, including the
+			// document root itself.
+			name: "chain-to-the-root",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: sutID}, {Id: "parent"}, {Id: "mid"}, {Id: "root"}},
+				Edges: []*Edge{
+					{Type: Edge_contains, From: "root", To: []string{"mid"}},
+					{Type: Edge_contains, From: "mid", To: []string{"parent"}},
+					{Type: Edge_contains, From: "parent", To: []string{sutID}},
+				},
+				RootElements: []string{"root"},
+			},
+			expectedNodesLength: 4,
+			depth:               10,
+		},
+		{
+			// Two direct parents:
+			//
+			//   parent1   parent2
+			//        \     /
+			//        mynode
+			name: "two-parents",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: sutID}, {Id: "parent1"}, {Id: "parent2"}},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "parent1", To: []string{sutID}},
+					{Type: Edge_contains, From: "parent2", To: []string{sutID}},
+				},
+				RootElements: []string{"parent1"},
+			},
+			expectedNodesLength: 3,
+			depth:               10,
+		},
+		{
+			// A diamond above the node must not duplicate the grandparent:
+			//
+			//        grandpa
+			//        /     \
+			//   parent1   parent2
+			//        \     /
+			//        mynode
+			name: "diamond",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: sutID}, {Id: "parent1"}, {Id: "parent2"}, {Id: "grandpa"}},
+				Edges: []*Edge{
+					{Type: Edge_contains, From: "grandpa", To: []string{"parent1", "parent2"}},
+					{Type: Edge_contains, From: "parent1", To: []string{sutID}},
+					{Type: Edge_contains, From: "parent2", To: []string{sutID}},
+				},
+				RootElements: []string{"grandpa"},
+			},
+			expectedNodesLength: 4,
+			depth:               10,
+		},
+		{
+			// The walk stops at ancestors that are document roots: the
+			// root is included, whatever points at it is not.
+			name: "stops-at-roots",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: sutID}, {Id: "root"}, {Id: "beyond"}},
+				Edges: []*Edge{
+					{Type: Edge_contains, From: "beyond", To: []string{"root"}},
+					{Type: Edge_contains, From: "root", To: []string{sutID}},
+				},
+				RootElements: []string{"root"},
+			},
+			expectedNodesLength: 2,
+			depth:               10,
+		},
+		{
+			name: "node-not-found",
+			sut: &NodeList{
+				Nodes:        []*Node{{Id: "other"}},
+				Edges:        []*Edge{},
+				RootElements: []string{"other"},
+			},
+			expectedNodesLength: 0,
+			depth:               10,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ancestors := tc.sut.NodeAncestors(sutID, tc.depth)
+			require.Len(t, ancestors.Nodes, tc.expectedNodesLength)
+		})
+	}
+
+	t.Run("fragment shape", func(t *testing.T) {
+		nl := &NodeList{
+			Nodes: []*Node{{Id: sutID}, {Id: "parent"}},
+			Edges: []*Edge{
+				{Type: Edge_contains, From: "parent", To: []string{sutID}},
+			},
+			RootElements: []string{"parent"},
+		}
+		result := nl.NodeAncestors(sutID, 10)
+		require.Equal(t, []string{sutID}, result.RootElements,
+			"the queried node is the fragment's root")
+		require.Len(t, result.Edges, 1)
+		require.True(t, result.Edges[0].Equal(
+			&Edge{Type: Edge_descendant, From: sutID, To: []string{"parent"}},
+		), "the ancestors relate to the queried node through a descendant edge")
+	})
+}

--- a/pkg/sbom/node_test.go
+++ b/pkg/sbom/node_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -858,4 +859,66 @@ func TestNodePurl(t *testing.T) {
 	require.Equal(t, PackageURL(""), file.Purl(), "files have no package URL")
 
 	require.Equal(t, PackageURL(""), (&Node{Type: Node_PACKAGE}).Purl())
+}
+
+// TestUpdateIsComplete checks Update against every field of the node: an
+// empty node updated from a full one must carry everything except the
+// identity fields (id and type), which Update never touches. A field added
+// to the proto that Update does not learn fails here.
+func TestUpdateIsComplete(t *testing.T) {
+	full := fullNode()
+	updated := &Node{}
+	updated.Update(full)
+
+	identity := map[protoreflect.Name]bool{"id": true, "type": true}
+	full.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, _ protoreflect.Value) bool {
+		if identity[fd.Name()] {
+			require.False(t, updated.ProtoReflect().Has(fd),
+				"Update must not touch the identity field %s", fd.Name())
+			return true
+		}
+		require.True(t, updated.ProtoReflect().Has(fd),
+			"Update does not carry %s", fd.Name())
+		return true
+	})
+
+	expected := fullNode()
+	expected.Id = ""
+	expected.Type = Node_PACKAGE
+	require.True(t, expected.Equal(updated), "the updated values do not match")
+}
+
+// TestUpdateSkipsEmptyFields checks the other half of the Update contract:
+// unset fields in the incoming node preserve the existing values.
+func TestUpdateSkipsEmptyFields(t *testing.T) {
+	full := fullNode()
+	full.Update(&Node{})
+	require.True(t, fullNode().Equal(full))
+}
+
+// TestAugmentIsComplete checks Augment against every field of the node: an
+// empty node augmented from a full one must carry everything except the
+// identity fields, and a full node augmented from anything must not change.
+func TestAugmentIsComplete(t *testing.T) {
+	full := fullNode()
+	augmented := &Node{}
+	augmented.Augment(full)
+
+	identity := map[protoreflect.Name]bool{"id": true, "type": true}
+	full.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, _ protoreflect.Value) bool {
+		if identity[fd.Name()] {
+			return true
+		}
+		require.True(t, augmented.ProtoReflect().Has(fd),
+			"Augment does not carry %s", fd.Name())
+		return true
+	})
+
+	set := fullNode()
+	other := fullNode()
+	other.Name = "a different name"
+	other.Version = "9.9.9"
+	other.Hashes = map[int32]string{int32(HashAlgorithm_SHA512): "fff"}
+	set.Augment(other)
+	require.True(t, fullNode().Equal(set), "Augment must not overwrite set fields")
 }

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -335,6 +335,66 @@ func (nl *NodeList) GetEdgeByType(fromElement string, t Edge_Type) *Edge {
 	return nil
 }
 
+// GetEdgesFrom returns the edges originating at the node with the given ID.
+// If the node has no outgoing relationships, the returned list is empty.
+func (nl *NodeList) GetEdgesFrom(id string) []*Edge {
+	ret := []*Edge{}
+	for _, e := range nl.Edges {
+		if e.From == id {
+			ret = append(ret, e)
+		}
+	}
+	return ret
+}
+
+// GetEdgesTo returns the edges pointing to the node with the given ID. If no
+// relationships point to the node, the returned list is empty.
+func (nl *NodeList) GetEdgesTo(id string) []*Edge {
+	ret := []*Edge{}
+	for _, e := range nl.Edges {
+		if e.PointsTo(id) {
+			ret = append(ret, e)
+		}
+	}
+	return ret
+}
+
+// UnrelateNodes removes the relationship of type t between the from node and
+// the to node. Other destinations of the matching edges are preserved; edges
+// left without destinations are removed from the list.
+func (nl *NodeList) UnrelateNodes(from, to string, t Edge_Type) {
+	newEdges := make([]*Edge, 0, len(nl.Edges))
+	for _, e := range nl.Edges {
+		if e.From == from && e.Type == t && e.PointsTo(to) {
+			newTos := make([]string, 0, len(e.To)-1)
+			for _, dest := range e.To {
+				if dest != to {
+					newTos = append(newTos, dest)
+				}
+			}
+			if len(newTos) == 0 {
+				continue
+			}
+			e.To = newTos
+		}
+		newEdges = append(newEdges, e)
+	}
+	nl.Edges = newEdges
+}
+
+// RemoveEdgesFrom removes all the edges of type t originating at the node
+// with the given ID.
+func (nl *NodeList) RemoveEdgesFrom(from string, t Edge_Type) {
+	newEdges := make([]*Edge, 0, len(nl.Edges))
+	for _, e := range nl.Edges {
+		if e.From == from && e.Type == t {
+			continue
+		}
+		newEdges = append(newEdges, e)
+	}
+	nl.Edges = newEdges
+}
+
 // copyEdgeList is a utility function that deep copies a list of edges
 func copyEdgeList(original []*Edge) []*Edge {
 	edgeCopy := make([]*Edge, 0, len(original))
@@ -1066,6 +1126,96 @@ func (nl *NodeList) NodeDescendants(id string, maxDepth int) *NodeList {
 	}
 	if len(ancestorEdge.To) > 0 {
 		nl2.Edges = append(nl2.Edges, ancestorEdge)
+	}
+	return &nl2
+}
+
+// NodeAncestors traverses the NodeList graph in the inverse direction of its
+// edges, starting at the node specified by id, and returns a new node list
+// with the elements pointing to it at a maximal distance of maxDepth levels.
+// If the specified id is not found, the NodeList will be empty.
+//
+// The traversal is structural, mirroring NodeDescendants: edges are walked
+// from destination to source whatever their type, so an edge stated with an
+// inverse type (such as contained_by) is not turned around. Traversing the
+// graph will stop at any related node that is a RootNode.
+//
+// In the resulting fragment the queried node is the sole root element and
+// the ancestors found relate to it through a single descendant edge, just as
+// NodeDescendants relates its results with an ancestor edge.
+func (nl *NodeList) NodeAncestors(id string, maxDepth int) *NodeList {
+	rootIdx := nl.indexRootElements()
+	nodeIdx := nl.indexNodes()
+	startNode := nodeIdx[id]
+	if startNode == nil {
+		return &NodeList{}
+	}
+
+	// Index the edges by their destinations to walk them backwards.
+	inboundIdx := map[string][]*Edge{}
+	for _, e := range nl.Edges {
+		for _, to := range e.To {
+			inboundIdx[to] = append(inboundIdx[to], e)
+		}
+	}
+
+	nl2 := NodeList{
+		Nodes:        []*Node{startNode},
+		Edges:        []*Edge{},
+		RootElements: []string{startNode.Id},
+	}
+
+	ancestors := nodeIndex{}
+
+	var loopNodes []*Node
+	newLoopNodes := []*Node{}
+
+	for i := 0; i <= maxDepth; i++ {
+		if i == 0 {
+			loopNodes = []*Node{startNode}
+		} else {
+			loopNodes = newLoopNodes
+		}
+		newLoopNodes = []*Node{}
+		for _, n := range loopNodes {
+			// If we've seen it, we're done
+			if _, ok := ancestors[n.Id]; ok {
+				continue
+			}
+
+			ancestors[n.Id] = n
+
+			// If nothing points to the node, we're done
+			if _, ok := inboundIdx[n.Id]; !ok {
+				continue
+			}
+
+			// If node is a root node, we're done
+			if _, ok := rootIdx[n.Id]; ok && n.Id != id {
+				continue
+			}
+
+			for _, e := range inboundIdx[n.Id] {
+				if _, ok := ancestors[e.From]; ok {
+					continue
+				}
+				if parent := nodeIdx[e.From]; parent != nil {
+					newLoopNodes = append(newLoopNodes, parent)
+				}
+			}
+		}
+	}
+
+	descendantEdge := &Edge{Type: Edge_descendant, From: id, To: []string{}}
+	for _, n := range ancestors {
+		if n.Id == id {
+			continue
+		}
+		nl2.Nodes = append(nl2.Nodes, n)
+		descendantEdge.To = append(descendantEdge.To, n.Id)
+	}
+	if len(descendantEdge.To) > 0 {
+		nl2.Edges = append(nl2.Edges, descendantEdge)
 	}
 	return &nl2
 }

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -1,6 +1,7 @@
 package sbom
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -1590,4 +1591,77 @@ func TestGetNodesByPurlTypeRoots(t *testing.T) {
 			require.Equal(t, tc.expectedRoots, got.RootElements)
 		})
 	}
+}
+
+// TestGetEdgeByType checks the edge lookup that the set operations build on,
+// including its contract of returning the first matching edge.
+func TestGetEdgeByType(t *testing.T) {
+	first := &Edge{Type: Edge_dependsOn, From: "a", To: []string{"b"}}
+	second := &Edge{Type: Edge_dependsOn, From: "a", To: []string{"c"}}
+	contains := &Edge{Type: Edge_contains, From: "a", To: []string{"d"}}
+	nl := &NodeList{Edges: []*Edge{first, second, contains}}
+
+	require.Same(t, first, nl.GetEdgeByType("a", Edge_dependsOn),
+		"the first matching edge is returned")
+	require.Same(t, contains, nl.GetEdgeByType("a", Edge_contains))
+	require.Nil(t, nl.GetEdgeByType("z", Edge_dependsOn))
+	require.Nil(t, nl.GetEdgeByType("a", Edge_testDependency))
+}
+
+// TestAddNode and TestAddEdge check the primitive append operations.
+func TestAddNode(t *testing.T) {
+	nl := &NodeList{}
+	nl.AddNode(&Node{Id: "a"})
+	nl.AddNode(&Node{Id: "b"})
+	require.Len(t, nl.Nodes, 2)
+	require.Empty(t, nl.RootElements, "adding a node does not make it a root")
+}
+
+func TestAddEdge(t *testing.T) {
+	nl := &NodeList{}
+	nl.AddEdge(&Edge{Type: Edge_dependsOn, From: "a", To: []string{"b"}})
+	nl.AddEdge(&Edge{Type: Edge_dependsOn, From: "a", To: []string{"c"}})
+	require.Len(t, nl.Edges, 2, "edges are appended, not merged (see MergeEdges)")
+}
+
+// TestAddRootNode checks adding top level nodes: registration as a root,
+// deduplication, and naming nodes that come without an ID.
+func TestAddRootNode(t *testing.T) {
+	t.Run("adds the node and registers the root", func(t *testing.T) {
+		nl := &NodeList{}
+		nl.AddRootNode(&Node{Id: "root-1", Name: "app"})
+		require.Len(t, nl.Nodes, 1)
+		require.Equal(t, []string{"root-1"}, nl.RootElements)
+	})
+
+	t.Run("an existing root is not duplicated", func(t *testing.T) {
+		nl := &NodeList{}
+		nl.AddRootNode(&Node{Id: "root-1", Name: "app"})
+		nl.AddRootNode(&Node{Id: "root-1", Name: "app"})
+		require.Len(t, nl.Nodes, 1)
+		require.Equal(t, []string{"root-1"}, nl.RootElements)
+	})
+
+	t.Run("an existing node is promoted without duplicating it", func(t *testing.T) {
+		nl := &NodeList{}
+		nl.AddNode(&Node{Id: "node-1", Name: "app"})
+		nl.AddRootNode(&Node{Id: "node-1", Name: "app"})
+		require.Len(t, nl.Nodes, 1)
+		require.Equal(t, []string{"node-1"}, nl.RootElements)
+	})
+
+	t.Run("a node without an ID is named after its name and version", func(t *testing.T) {
+		nl := &NodeList{}
+		node := &Node{Name: "app", Version: "1.0.0"}
+		nl.AddRootNode(node)
+		require.NotEmpty(t, node.Id)
+		require.True(t, strings.HasPrefix(node.Id, "protobom-auto-"), node.Id)
+		require.Equal(t, []string{node.Id}, nl.RootElements)
+
+		// The generated name is deterministic, so adding another nameless
+		// node describing the same software dedups against the first.
+		nl.AddRootNode(&Node{Name: "app", Version: "1.0.0"})
+		require.Len(t, nl.Nodes, 1)
+		require.Len(t, nl.RootElements, 1)
+	})
 }

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -1911,3 +1911,95 @@ func TestGetNodesByPurlType(t *testing.T) {
 
 	require.Empty(t, nl.GetNodesByPurlType("deb").Nodes)
 }
+
+// TestGetEdgesFrom checks listing the outgoing relationships of a node.
+func TestGetEdgesFrom(t *testing.T) {
+	deps := &Edge{Type: Edge_dependsOn, From: "a", To: []string{"b"}}
+	contains := &Edge{Type: Edge_contains, From: "a", To: []string{"c"}}
+	other := &Edge{Type: Edge_dependsOn, From: "b", To: []string{"c"}}
+	nl := &NodeList{Edges: []*Edge{deps, contains, other}}
+
+	edges := nl.GetEdgesFrom("a")
+	require.Len(t, edges, 2)
+	require.Same(t, deps, edges[0])
+	require.Same(t, contains, edges[1])
+
+	require.Empty(t, nl.GetEdgesFrom("c"))
+	require.Empty(t, nl.GetEdgesFrom("not-here"))
+}
+
+// TestGetEdgesTo checks listing the relationships pointing to a node.
+func TestGetEdgesTo(t *testing.T) {
+	deps := &Edge{Type: Edge_dependsOn, From: "a", To: []string{"b", "c"}}
+	contains := &Edge{Type: Edge_contains, From: "b", To: []string{"c"}}
+	nl := &NodeList{Edges: []*Edge{deps, contains}}
+
+	edges := nl.GetEdgesTo("c")
+	require.Len(t, edges, 2)
+	require.Same(t, deps, edges[0])
+	require.Same(t, contains, edges[1])
+
+	require.Len(t, nl.GetEdgesTo("b"), 1)
+	require.Empty(t, nl.GetEdgesTo("a"))
+	require.Empty(t, nl.GetEdgesTo("not-here"))
+}
+
+// TestUnrelateNodes checks removing a single relationship: other
+// destinations survive, emptied edges are dropped and everything else is
+// left alone.
+func TestUnrelateNodes(t *testing.T) {
+	build := func() *NodeList {
+		return &NodeList{
+			Nodes: []*Node{{Id: "a"}, {Id: "b"}, {Id: "c"}},
+			Edges: []*Edge{
+				{Type: Edge_dependsOn, From: "a", To: []string{"b", "c"}},
+				{Type: Edge_contains, From: "a", To: []string{"b"}},
+			},
+			RootElements: []string{"a"},
+		}
+	}
+
+	t.Run("other destinations survive", func(t *testing.T) {
+		nl := build()
+		nl.UnrelateNodes("a", "b", Edge_dependsOn)
+		require.Len(t, nl.Edges, 2)
+		require.True(t, nl.Edges[0].Equal(&Edge{Type: Edge_dependsOn, From: "a", To: []string{"c"}}))
+		require.True(t, nl.Edges[1].Equal(&Edge{Type: Edge_contains, From: "a", To: []string{"b"}}),
+			"other edge types are left alone")
+	})
+
+	t.Run("an emptied edge is dropped", func(t *testing.T) {
+		nl := build()
+		nl.UnrelateNodes("a", "b", Edge_contains)
+		require.Len(t, nl.Edges, 1)
+		require.Equal(t, Edge_dependsOn, nl.Edges[0].Type)
+	})
+
+	t.Run("an absent relationship is a no-op", func(t *testing.T) {
+		nl := build()
+		nl.UnrelateNodes("b", "a", Edge_dependsOn)
+		nl.UnrelateNodes("a", "not-here", Edge_dependsOn)
+		require.True(t, build().Equal(nl))
+	})
+}
+
+// TestRemoveEdgesFrom checks removing all relationships of one type
+// originating at a node.
+func TestRemoveEdgesFrom(t *testing.T) {
+	nl := &NodeList{
+		Edges: []*Edge{
+			{Type: Edge_dependsOn, From: "a", To: []string{"b"}},
+			{Type: Edge_dependsOn, From: "a", To: []string{"c"}},
+			{Type: Edge_contains, From: "a", To: []string{"b"}},
+			{Type: Edge_dependsOn, From: "b", To: []string{"c"}},
+		},
+	}
+
+	nl.RemoveEdgesFrom("a", Edge_dependsOn)
+	require.Len(t, nl.Edges, 2, "all matching edges go, including duplicates")
+	require.Equal(t, Edge_contains, nl.Edges[0].Type)
+	require.Equal(t, "b", nl.Edges[1].From)
+
+	nl.RemoveEdgesFrom("not-here", Edge_dependsOn)
+	require.Len(t, nl.Edges, 2, "an unknown source is a no-op")
+}

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -102,12 +102,13 @@ func TestCleanEdges(t *testing.T) {
 
 func TestRemoveNodes(t *testing.T) {
 	for _, tc := range []struct {
+		name     string
 		sut      *NodeList
 		prep     func(*NodeList)
 		expected *NodeList
 	}{
 		{
-			// Two related edges. Remove the second
+			name: "two related edges, remove the second",
 			sut: &NodeList{
 				Nodes: []*Node{
 					{Id: "node1"}, {Id: "node2"},
@@ -132,9 +133,97 @@ func TestRemoveNodes(t *testing.T) {
 				RootElements: []string{"node1"},
 			},
 		},
+		{
+			name: "removing a root cleans the root elements",
+			sut: &NodeList{
+				Nodes:        []*Node{{Id: "node1"}, {Id: "node2"}},
+				Edges:        []*Edge{},
+				RootElements: []string{"node1", "node2"},
+			},
+			prep: func(nl *NodeList) {
+				nl.RemoveNodes([]string{"node1"})
+			},
+			expected: &NodeList{
+				Nodes:        []*Node{{Id: "node2"}},
+				Edges:        []*Edge{},
+				RootElements: []string{"node2"},
+			},
+		},
+		{
+			name: "removing one destination keeps the edge for the others",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: "node1"}, {Id: "node2"}, {Id: "node3"}},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "node1", To: []string{"node2", "node3"}},
+				},
+				RootElements: []string{"node1"},
+			},
+			prep: func(nl *NodeList) {
+				nl.RemoveNodes([]string{"node2"})
+			},
+			expected: &NodeList{
+				Nodes: []*Node{{Id: "node1"}, {Id: "node3"}},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "node1", To: []string{"node3"}},
+				},
+				RootElements: []string{"node1"},
+			},
+		},
+		{
+			name: "removing the edge source drops the edge",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: "node1"}, {Id: "node2"}},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "node1", To: []string{"node2"}},
+				},
+				RootElements: []string{"node1"},
+			},
+			prep: func(nl *NodeList) {
+				nl.RemoveNodes([]string{"node1"})
+			},
+			expected: &NodeList{
+				Nodes:        []*Node{{Id: "node2"}},
+				Edges:        []*Edge{},
+				RootElements: []string{},
+			},
+		},
+		{
+			name: "several nodes at once",
+			sut: &NodeList{
+				Nodes:        []*Node{{Id: "node1"}, {Id: "node2"}, {Id: "node3"}},
+				Edges:        []*Edge{},
+				RootElements: []string{"node1"},
+			},
+			prep: func(nl *NodeList) {
+				nl.RemoveNodes([]string{"node2", "node3"})
+			},
+			expected: &NodeList{
+				Nodes:        []*Node{{Id: "node1"}},
+				Edges:        []*Edge{},
+				RootElements: []string{"node1"},
+			},
+		},
+		{
+			name: "an unknown id is a no-op",
+			sut: &NodeList{
+				Nodes:        []*Node{{Id: "node1"}},
+				Edges:        []*Edge{},
+				RootElements: []string{"node1"},
+			},
+			prep: func(nl *NodeList) {
+				nl.RemoveNodes([]string{"not-here"})
+			},
+			expected: &NodeList{
+				Nodes:        []*Node{{Id: "node1"}},
+				Edges:        []*Edge{},
+				RootElements: []string{"node1"},
+			},
+		},
 	} {
-		tc.prep(tc.sut)
-		require.Equal(t, tc.expected, tc.sut)
+		t.Run(tc.name, func(t *testing.T) {
+			tc.prep(tc.sut)
+			require.True(t, tc.expected.Equal(tc.sut), "%+v", tc.sut)
+		})
 	}
 }
 
@@ -1664,4 +1753,161 @@ func TestAddRootNode(t *testing.T) {
 		require.Len(t, nl.Nodes, 1)
 		require.Len(t, nl.RootElements, 1)
 	})
+}
+
+// TestUnionMergesEdges checks that union merges the destinations of edges
+// sharing a source and type instead of duplicating the edge.
+func TestUnionMergesEdges(t *testing.T) {
+	nl1 := &NodeList{
+		Nodes: []*Node{{Id: "a"}, {Id: "b"}},
+		Edges: []*Edge{
+			{Type: Edge_dependsOn, From: "a", To: []string{"b"}},
+		},
+		RootElements: []string{"a"},
+	}
+	nl2 := &NodeList{
+		Nodes: []*Node{{Id: "a"}, {Id: "b"}, {Id: "c"}},
+		Edges: []*Edge{
+			{Type: Edge_dependsOn, From: "a", To: []string{"b", "c"}},
+		},
+		RootElements: []string{"a"},
+	}
+
+	result := nl1.Union(nl2)
+	require.Len(t, result.Nodes, 3)
+	require.Len(t, result.Edges, 1, "equivalent edges must merge")
+	require.True(t, result.Edges[0].Equal(
+		&Edge{Type: Edge_dependsOn, From: "a", To: []string{"b", "c"}},
+	), result.Edges[0].flatString())
+}
+
+// TestUnionMergesRoots checks that the root elements of both sides are
+// combined without duplicates.
+func TestUnionMergesRoots(t *testing.T) {
+	nl1 := &NodeList{
+		Nodes:        []*Node{{Id: "a"}},
+		RootElements: []string{"a"},
+	}
+	nl2 := &NodeList{
+		Nodes:        []*Node{{Id: "a"}, {Id: "b"}},
+		RootElements: []string{"a", "b"},
+	}
+
+	require.Equal(t, []string{"a", "b"}, nl1.Union(nl2).RootElements)
+}
+
+// TestUnionUpdatesNodes checks the merge semantics for nodes on both sides:
+// set fields in the second list win, unset ones preserve the first.
+func TestUnionUpdatesNodes(t *testing.T) {
+	nl1 := &NodeList{
+		Nodes:        []*Node{{Id: "a", Name: "app", Version: "1.0.0", Comment: "from one"}},
+		RootElements: []string{"a"},
+	}
+	nl2 := &NodeList{
+		Nodes:        []*Node{{Id: "a", Name: "app", Version: "2.0.0"}},
+		RootElements: []string{"a"},
+	}
+
+	result := nl1.Union(nl2)
+	require.Len(t, result.Nodes, 1)
+	require.Equal(t, "2.0.0", result.Nodes[0].Version, "set fields in the second list win")
+	require.Equal(t, "from one", result.Nodes[0].Comment, "unset fields preserve the first list")
+}
+
+// TestIntersectDisjoint checks that intersecting lists with no common nodes
+// produces an empty nodelist.
+func TestIntersectDisjoint(t *testing.T) {
+	nl1 := &NodeList{
+		Nodes:        []*Node{{Id: "a"}},
+		RootElements: []string{"a"},
+	}
+	nl2 := &NodeList{
+		Nodes:        []*Node{{Id: "b"}},
+		RootElements: []string{"b"},
+	}
+
+	result := nl1.Intersect(nl2)
+	require.Empty(t, result.Nodes)
+	require.Empty(t, result.Edges)
+	require.Empty(t, result.RootElements)
+}
+
+// TestIntersectCleansEdges checks that edges pointing outside the
+// intersection are dropped and roots from either side are kept.
+func TestIntersectCleansEdges(t *testing.T) {
+	nl1 := &NodeList{
+		Nodes: []*Node{{Id: "a"}, {Id: "b"}},
+		Edges: []*Edge{
+			{Type: Edge_dependsOn, From: "a", To: []string{"b"}},
+		},
+		RootElements: []string{"a"},
+	}
+	nl2 := &NodeList{
+		Nodes: []*Node{{Id: "b"}, {Id: "c"}},
+		Edges: []*Edge{
+			{Type: Edge_dependsOn, From: "b", To: []string{"c"}},
+		},
+		RootElements: []string{"b"},
+	}
+
+	result := nl1.Intersect(nl2)
+	require.Len(t, result.Nodes, 1)
+	require.Equal(t, "b", result.Nodes[0].Id)
+	require.Empty(t, result.Edges, "edges reaching outside the intersection are dropped")
+	require.Equal(t, []string{"b"}, result.RootElements,
+		"a node that is a root on either side stays a root")
+}
+
+// TestIntersectUpdatesNodes checks that common nodes carry the data of the
+// second list over the first.
+func TestIntersectUpdatesNodes(t *testing.T) {
+	nl1 := &NodeList{
+		Nodes:        []*Node{{Id: "a", Name: "app", Version: "1.0.0", Comment: "from one"}},
+		RootElements: []string{"a"},
+	}
+	nl2 := &NodeList{
+		Nodes:        []*Node{{Id: "a", Name: "app", Version: "2.0.0"}},
+		RootElements: []string{"a"},
+	}
+
+	result := nl1.Intersect(nl2)
+	require.Len(t, result.Nodes, 1)
+	require.Equal(t, "2.0.0", result.Nodes[0].Version)
+	require.Equal(t, "from one", result.Nodes[0].Comment)
+}
+
+// TestGetNodesByPurlType checks the purl prefix matching itself (the root
+// recomputation of the resulting list is covered in
+// TestGetNodesByPurlTypeRoots).
+func TestGetNodesByPurlType(t *testing.T) {
+	purl := func(p string) map[int32]string {
+		return map[int32]string{int32(SoftwareIdentifierType_PURL): p}
+	}
+	nl := &NodeList{
+		Nodes: []*Node{
+			{Id: "npm1", Identifiers: purl("pkg:npm/express@4.0.0")},
+			{Id: "npm2", Identifiers: purl("pkg:/npm/slashed@1.0.0")},
+			{Id: "golang", Identifiers: purl("pkg:golang/github.com/protobom/protobom@0.5.0")},
+			{Id: "bare"},
+		},
+		Edges: []*Edge{
+			{Type: Edge_dependsOn, From: "npm1", To: []string{"npm2"}},
+			{Type: Edge_dependsOn, From: "golang", To: []string{"npm1"}},
+		},
+		RootElements: []string{"golang"},
+	}
+
+	result := nl.GetNodesByPurlType("npm")
+	ids := make([]string, 0, len(result.Nodes))
+	for _, n := range result.Nodes {
+		ids = append(ids, n.Id)
+	}
+	require.Equal(t, []string{"npm1", "npm2"}, ids,
+		"both purl spellings match, other types and bare nodes do not")
+	require.Len(t, result.Edges, 1, "only edges between matching nodes survive")
+	require.True(t, result.Edges[0].Equal(
+		&Edge{Type: Edge_dependsOn, From: "npm1", To: []string{"npm2"}},
+	))
+
+	require.Empty(t, nl.GetNodesByPurlType("deb").Nodes)
 }

--- a/pkg/sbom/person.go
+++ b/pkg/sbom/person.go
@@ -56,7 +56,10 @@ func (p *Person) flatString() string {
 	if p.Phone != "" {
 		s += fmt.Sprintf("p(%s)", p.Phone)
 	}
-	if p.Contacts != nil {
+	// An empty contact list and no contact list are the same statement, so
+	// they must produce the same string: a copy of a person initializes the
+	// list and still has to be equal to its original.
+	if len(p.Contacts) > 0 {
 		s += "c("
 		for _, c := range p.Contacts {
 			s += c.flatString()

--- a/pkg/sbom/value_scanner_test.go
+++ b/pkg/sbom/value_scanner_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Protobom Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sbom
+
+import (
+	"database/sql/driver"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// valuerScanner is what every persistable protobom type implements.
+type valuerScanner interface {
+	proto.Message
+	Value() (driver.Value, error)
+	Scan(src any) error
+}
+
+// TestValueScanRoundTrip stores each of the persistable types through its
+// database driver interface and reads it back.
+func TestValueScanRoundTrip(t *testing.T) {
+	docType := DocumentType_BUILD
+	name := "doctype"
+
+	for _, original := range []valuerScanner{
+		&Document{
+			Metadata: &Metadata{Id: "urn:uuid:11111111-2222-3333-4444-555555555555", Version: "1"},
+			NodeList: &NodeList{
+				Nodes:        []*Node{fullNode()},
+				Edges:        []*Edge{{Type: Edge_dependsOn, From: "a", To: []string{"b"}}},
+				RootElements: []string{"a"},
+			},
+		},
+		&DocumentType{Type: &docType, Name: &name},
+		&Edge{Type: Edge_contains, From: "a", To: []string{"b", "c"}},
+		&ExternalReference{Url: "https://example.com", Type: ExternalReference_VCS, Comment: "c"},
+		&Metadata{
+			Id: "urn:uuid:11111111-2222-3333-4444-555555555555", Version: "3",
+			Name:  "a document",
+			Tools: []*Tool{{Vendor: "ACME", Name: "tool", Version: "1.0"}},
+			Authors: []*Person{
+				{Name: "Jane", Email: "jane@example.com"},
+			},
+		},
+		fullNode(),
+		&NodeList{
+			Nodes:        []*Node{fullNode()},
+			Edges:        []*Edge{{Type: Edge_dependsOn, From: "a", To: []string{"b"}}},
+			RootElements: []string{"a"},
+		},
+		fullPerson(),
+		&Property{Name: "prop", Data: "data"},
+		&SourceData{Format: "text/spdx+json;version=2.3", Size: 1024},
+		&Tool{Vendor: "ACME", Name: "tool", Version: "1.0"},
+	} {
+		t.Run(string(original.ProtoReflect().Descriptor().Name()), func(t *testing.T) {
+			stored, err := original.Value()
+			require.NoError(t, err)
+			data, ok := stored.([]byte)
+			require.True(t, ok, "the driver value is a byte slice")
+			require.NotEmpty(t, data)
+
+			read, ok := original.ProtoReflect().New().Interface().(valuerScanner)
+			require.True(t, ok)
+			require.NoError(t, read.Scan(data))
+			require.True(t, proto.Equal(original, read),
+				"the scanned message does not match the stored one")
+		})
+	}
+}
+
+// TestValueIsDeterministic checks that storing the same message twice
+// produces the same bytes, which the driver value promises by marshaling
+// deterministically.
+func TestValueIsDeterministic(t *testing.T) {
+	// A node with several map entries is where map ordering would show.
+	node := fullNode()
+	node.Hashes = map[int32]string{
+		int32(HashAlgorithm_SHA1):   "aaa",
+		int32(HashAlgorithm_SHA256): "bbb",
+		int32(HashAlgorithm_SHA512): "ccc",
+	}
+	node.Identifiers = map[int32]string{
+		int32(SoftwareIdentifierType_PURL):  "pkg:generic/a@1",
+		int32(SoftwareIdentifierType_CPE23): "cpe:2.3:a:example:a:1:*:*:*:*:*:*:*",
+	}
+
+	first, err := node.Value()
+	require.NoError(t, err)
+	second, err := node.Value()
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+// TestScanContract checks the scanning corner cases: a database NULL leaves
+// the message untouched, and anything but bytes is refused.
+func TestScanContract(t *testing.T) {
+	t.Run("nil leaves the message untouched", func(t *testing.T) {
+		node := fullNode()
+		before := proto.Clone(node)
+		require.NoError(t, node.Scan(nil))
+		require.True(t, proto.Equal(before, node))
+	})
+
+	t.Run("an unexpected type errors", func(t *testing.T) {
+		require.Error(t, (&Node{}).Scan("not bytes"))
+		require.Error(t, (&Node{}).Scan(42))
+	})
+
+	t.Run("garbage bytes error", func(t *testing.T) {
+		require.Error(t, (&Node{}).Scan([]byte{0xff, 0xff, 0xff, 0xff}))
+	})
+}


### PR DESCRIPTION
This pull request introduces several enhancements and new tests to the SBOM (Software Bill of Materials) package, focusing on improving node and edge relationship handling, increasing test coverage, and ensuring correctness and completeness of core functionality. The main areas of change are new graph traversal capabilities, expanded and more thorough testing of node and edge behaviors, and minor bug fixes.

**Graph traversal and relationship management:**
* Added `NodeAncestors` method to `NodeList` to traverse and extract ancestor nodes structurally, mirroring the existing descendant traversal. This also ensures the resulting fragment is well-formed and includes appropriate edges.
* Introduced utility methods to `NodeList` for managing relationships: `GetEdgesFrom`, `GetEdgesTo`, `UnrelateNodes`, and `RemoveEdgesFrom`, allowing fine-grained manipulation and querying of node relationships.

**Node and edge comparison and diff improvements:**
* Enhanced the `Node.Diff` method to compare `ContentType` and `FileKind` fields, ensuring that all relevant node fields are included in diffs.
* Added comprehensive tests for node equality, hash matching, checksum stability, PURL extraction, and completeness of `Update` and `Augment` methods, verifying that all fields are correctly handled and compared.

**Test coverage and documentation:**
* Added tests for edge behavior, including the new `PointsTo` method and edge equality checks.
* Expanded and improved example-based and unit tests for document root node handling and metadata population, ensuring that API usage is well-documented and correct. [[1]](diffhunk://#diff-5311f43cd5baead10cd934387cae105e6b5c5050b720cf0449d066fe8c97cdb5L3-R10) [[2]](diffhunk://#diff-5311f43cd5baead10cd934387cae105e6b5c5050b720cf0449d066fe8c97cdb5R44-R50) [[3]](diffhunk://#diff-5311f43cd5baead10cd934387cae105e6b5c5050b720cf0449d066fe8c97cdb5R79-R85) [[4]](diffhunk://#diff-5311f43cd5baead10cd934387cae105e6b5c5050b720cf0449d066fe8c97cdb5R129-R148)

**Bug fixes and correctness:**
* Fixed a subtle bug in `Person.flatString` to treat empty and nil contact lists equivalently, ensuring that equality and serialization remain correct after copying.

**Test completeness checks:**
* Added tests to automatically verify that all fields are compared in `Node.Diff` and handled in `Node.Update` and `Node.Augment`, helping to catch omissions when new fields are added. [[1]](diffhunk://#diff-9bf832d6ecbdba36161c675d10154597008a82424608dd44bdb8dee8b3f0f028R1178-R1193) [[2]](diffhunk://#diff-355cb7473b54914be31ed3de21db25b6216cfa899688ec14a2b5e7fc1b72b1b3R712-R1067)

These changes collectively improve the robustness, correctness, and maintainability of the SBOM package.